### PR TITLE
Fix model status icon

### DIFF
--- a/pgml-admin/app/models.py
+++ b/pgml-admin/app/models.py
@@ -100,6 +100,10 @@ class Model(models.Model):
     def key_metric(self):
         return self.metrics[self.project.key_metric_name]
 
+    def live(self):
+        last_deployment = Deployment.objects.filter(project=self.project).last()
+        return last_deployment.model.pk == self.pk
+
 
 class Deployment(models.Model):
     project = models.ForeignKey(Project, on_delete=models.CASCADE)

--- a/pgml-admin/app/templates/models/model.html
+++ b/pgml-admin/app/templates/models/model.html
@@ -4,7 +4,7 @@
 {% block main %}
 <section>
   <h1><span class="material-symbols-outlined">model_training</span>{{ object.algorithm_name }}
-    {% if live %}
+    {% if object.live %}
       <span class="material-symbols-outlined success">star</span>
     {% else %}
       <span class="material-symbols-outlined">cancel</span>


### PR DESCRIPTION
The `live` icon status was not specified, so all models were "cancelled". This introduces the definition of a "live" model and updates the template to use that definition, fixing the bug.

![image](https://user-images.githubusercontent.com/9561483/166178426-ff470348-a854-4a04-9ec8-16b358939d93.png)
