### PR TITLE
Cleanup blame view in GitHub.

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# Fixed Windows line endings.
+5d91e570a567c4b9059e66b36421b007d00f889f


### PR DESCRIPTION
This prevents #97 from obscuring change history (ref:  [GitHub docs](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view))