### PR TITLE
Fix Chrome js. Minor look change for hyperparams

### DIFF
--- a/pgml-dashboard/app/static/js/controllers/new-project.js
+++ b/pgml-dashboard/app/static/js/controllers/new-project.js
@@ -173,11 +173,11 @@ export default class extends Controller {
       .then(html => this.analysisResultTarget.innerHTML = html)
       .then(() => {
         // Render charts
-        for (name in snapshotData.columns) {
+        for (let name in snapshotData.columns) {
           const sample = JSON.parse(document.getElementById(name).textContent)
           renderDistribution(name, sample, snapshotData.analysis[`${name}_dip`])
 
-          for (target of snapshotData.y_column_name) {
+          for (let target of snapshotData.y_column_name) {
             if (target === name)
               continue
 
@@ -186,7 +186,7 @@ export default class extends Controller {
           }
         }
 
-        for (target of snapshotData.y_column_name) {
+        for (let target of snapshotData.y_column_name) {
           const targetSample = JSON.parse(document.getElementById(target).textContent)
           renderOutliers(target, targetSample, snapshotData.analysis[`${target}_stddev`])
         }

--- a/pgml-dashboard/app/templates/models/model.html
+++ b/pgml-dashboard/app/templates/models/model.html
@@ -56,7 +56,7 @@
   <h2>Hyperparam Search - {{ object.search }}</h2>
   {% for param, values in search_params.items %}
     <h3>{{ param }}</h3>
-    <p>{{ values }}</p>
+    <pre><code>{{ values }}</code></pre>
     {% for graph, graph_attrs in search_graphs.items %}
       <figure id="graph_{{param}}_{{graph}}"></figure>
     {% endfor %}


### PR DESCRIPTION
Use `<pre><code>` to show the hyperparameter arguments:

![image](https://user-images.githubusercontent.com/9561483/168443412-faddfc91-edd4-4fb9-b8e2-a73b0b6efff3.png)

Fix Chrome ES5, requiring `let` for loop variables.