### PR TITLE
Add debounce to new project wizard; fix quick predictions

### DIFF
--- a/pgml-dashboard/app/static/js/controllers/new-project.js
+++ b/pgml-dashboard/app/static/js/controllers/new-project.js
@@ -25,6 +25,9 @@ export default class extends Controller {
         this.index = 0
         this.targetNames = new Set()
         this.algorithmNames = new Set()
+
+        this.checkDataSourceDebounced = _.debounce(this.checkDataSource, 250)
+        this.checkProjectNameDebounced = _.debounce(this.checkProjectName, 250)
     }
 
     renderSteps() {

--- a/pgml-dashboard/app/static/js/controllers/quick-prediction.js
+++ b/pgml-dashboard/app/static/js/controllers/quick-prediction.js
@@ -52,7 +52,9 @@ export default class extends Controller {
     })
     .then(res => res.json())
     .then(json => {
-      this.predictionTarget.innerHTML = json.prediction
+      this.predictionTargets.forEach((element, index) => {
+        element.innerHTML = json.predictions[index]
+      })
       this.nextStep()
     })
   }

--- a/pgml-dashboard/app/templates/models/model.html
+++ b/pgml-dashboard/app/templates/models/model.html
@@ -81,8 +81,10 @@
     <h2>Prediction</h2>
 
     <dl>
-      <dt>{{ object.snapshot.y_column_name.0 }}</dt>
+      {% for y_column_name in object.snapshot.y_column_name %}
+      <dt>{{ y_column_name }}</dt>
       <dd data-quick-prediction-target="prediction"></dd>
+      {% endfor %}
     </dl>
 
     <div class="button-container">

--- a/pgml-dashboard/app/templates/projects/new.html
+++ b/pgml-dashboard/app/templates/projects/new.html
@@ -10,7 +10,7 @@
     <h2>Project name</h2>
 
     <div class="input-container">
-      <input type="text" name="name" placeholder="New unique project name" size="50" data-action="input->new-project#checkProjectName" />
+      <input type="text" name="name" placeholder="New unique project name" size="50" data-action="input->new-project#checkProjectNameDebounced" />
       <span class="material-symbols-outlined" data-new-project-target="projectStatus"></span>
     </div>
 
@@ -40,7 +40,7 @@
     <h2>Data source</h2>
 
     <div class="input-container">
-      <input type="text" name="name" placeholder="Table or view name" size="50" data-action="input->new-project#checkDataSource" list="table-list" />
+      <input type="text" name="name" placeholder="Table or view name" size="50" data-action="input->new-project#checkDataSourceDebounced" list="table-list" />
       <datalist id="table-list">
         {% for table in tables %}
         <option value="{{ table }}">

--- a/pgml-dashboard/app/views/models.py
+++ b/pgml-dashboard/app/views/models.py
@@ -90,6 +90,8 @@ class ModelViewSet(viewsets.ModelViewSet):
     def predict(self, request, pk=None):
         model = get_object_or_404(Model, pk=pk)
 
+        print("Data: ", request.data)
+
         with connection.cursor() as cursor:
             cursor.execute(
                 """
@@ -103,7 +105,7 @@ class ModelViewSet(viewsets.ModelViewSet):
             result = cursor.fetchone()
 
             data = {
-                "prediction": result[0],
+                "predictions": result[0],
             }
 
             return Response(data)

--- a/pgml-dashboard/app/views/models.py
+++ b/pgml-dashboard/app/views/models.py
@@ -90,8 +90,6 @@ class ModelViewSet(viewsets.ModelViewSet):
     def predict(self, request, pk=None):
         model = get_object_or_404(Model, pk=pk)
 
-        print("Data: ", request.data)
-
         with connection.cursor() as cursor:
             cursor.execute(
                 """

--- a/pgml-extension/pgml_extension/__init__.py
+++ b/pgml-extension/pgml_extension/__init__.py
@@ -1,2 +1,2 @@
 def version():
-    return "0.8.4"
+    return "0.9.0"

--- a/pgml-extension/sql/install/models.sql
+++ b/pgml-extension/sql/install/models.sql
@@ -200,9 +200,16 @@ CREATE OR REPLACE FUNCTION pgml.model_predict(
 	model_id BIGINT, -- `id` from `pgml.models`
 	features DOUBLE PRECISION[] -- list of features that the model accepts
 )
-RETURNS DOUBLE PRECISION
+RETURNS DOUBLE PRECISION[]
 AS $$
 	from pgml_extension.model import Model
+	from collections.abc import Iterable
+
 	model = Model.find_by_id(model_id)
-	return model.predict(features)
+	pred = model.predict(features)
+
+	if isinstance(pred, Iterable):
+		return list(pred)
+	else:
+		return [pred]
 $$ LANGUAGE plpython3u;


### PR DESCRIPTION
1. Add `_.debounce` to fetch calls in new project wizard.
2. Add support in Quick Prediction for models with multiple labels.