### PR TITLE
Fixed the link to the quickstart

### DIFF
--- a/pgml-docs/docs/index.md
+++ b/pgml-docs/docs/index.md
@@ -115,7 +115,7 @@ ORDER BY prediction DESC;
 </div>
 
 <p align="center" markdown>
-  [Get Started](/user_guides/installation/quick_start_with_docker/){ .md-button .md-button--primary }
+  [Get Started](/user_guides/setup/quick_start_with_docker/){ .md-button .md-button--primary }
 </p>
 ## What's in the box
 


### PR DESCRIPTION
If you go to the main page of the website and click on "Get Started", it would show 404 Page Not Found. I just changed the endpoint to make it point to the right page.