### PR TITLE
Strip html tags from markdown

### DIFF
--- a/pgml-dashboard/notebooks/migrations/0008_auto_20220815_2256.py
+++ b/pgml-dashboard/notebooks/migrations/0008_auto_20220815_2256.py
@@ -6,19 +6,19 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('notebooks', '0007_alter_notebook_name'),
+        ("notebooks", "0007_alter_notebook_name"),
     ]
 
     operations = [
         migrations.RenameField(
-            model_name='notebookline',
-            old_name='line_number',
-            new_name='cell_number',
+            model_name="notebookline",
+            old_name="line_number",
+            new_name="cell_number",
         ),
         migrations.RenameField(
-            model_name='notebookline',
-            old_name='line_type',
-            new_name='cell_type',
+            model_name="notebookline",
+            old_name="line_type",
+            new_name="cell_type",
         ),
-        migrations.RenameModel('NotebookLine', 'NotebookCell'),
+        migrations.RenameModel("NotebookLine", "NotebookCell"),
     ]

--- a/pgml-dashboard/notebooks/models.py
+++ b/pgml-dashboard/notebooks/models.py
@@ -3,6 +3,7 @@ from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
 from django.db.utils import ProgrammingError
 from django.utils import timezone
+from django.utils.html import strip_tags
 
 import markdown
 

--- a/pgml-dashboard/notebooks/views.py
+++ b/pgml-dashboard/notebooks/views.py
@@ -4,6 +4,7 @@ from django.http import HttpResponse, HttpResponseRedirect
 from django import forms
 from django.db import transaction
 from django.utils import timezone
+from django.utils.html import strip_tags
 
 from notebooks.models import *
 import time
@@ -114,7 +115,7 @@ def add_notebook_cell(request, pk):
 
         cell = NotebookCell.objects.create(
             notebook=notebook,
-            contents=cell_form.cleaned_data["contents"].strip(),
+            contents=strip_tags(cell_form.cleaned_data["contents"].strip()),
             cell_number=(last_cell.cell_number + 1 if last_cell else 1),
             cell_type=cell_type,
         )
@@ -156,7 +157,7 @@ def edit_notebook_cell(request, notebook_pk, cell_pk):
         else:
             cell_type = NotebookCell.MARKDOWN
 
-        cell.contents = cell_form.cleaned_data["contents"].strip()
+        cell.contents = strip_tags(cell_form.cleaned_data["contents"].strip())
         cell.cell_type = cell_type
 
         # If cell was changed to Markdown, remove execution time.


### PR DESCRIPTION
Protect against injecting html into the page via markdown (e.g. scripts).