### PR TITLE
Multi-tenant dashboard

### DIFF
--- a/pgml-dashboard/app/management/commands/auth_token.py
+++ b/pgml-dashboard/app/management/commands/auth_token.py
@@ -1,0 +1,14 @@
+import jwt
+import djclick as click
+
+from django.conf import settings
+
+
+@click.command()
+@click.option("--shard", default="0")
+def command(shard):
+    """Generate an auth token."""
+    claim = {"dashboard": "1234", "shard": shard}
+
+    token = jwt.encode(claim, settings.SECRET_KEY, algorithm="HS256")
+    print(token)

--- a/pgml-dashboard/app/middleware.py
+++ b/pgml-dashboard/app/middleware.py
@@ -45,13 +45,11 @@ class JwtAuthentcationMiddleware:
                 # Extract the token assuming "Bearer <token>"
                 token = auth_header.split(" ")[-1]
 
-            print(token)
             token = jwt.decode(token, settings.SECRET_KEY, algorithms=["HS256"])
             request.dashboard_uuid = token["dashboard"]
             if "shard" in token:
-                request.shard = int(token["shard"])
-        except Exception as e:
-            print(e)
+                request.shard = token["shard"]
+        except Exception:
             return HttpResponse(PERMISSION_DENIED, status=403)
 
         return self.get_response(request)
@@ -70,5 +68,5 @@ class MultiTenantMiddleware:
             with connection.cursor() as cursor:
                 shard = request.shard
                 # https://github.com/levkk/pgcat
-                cursor.execute(f"SET SHARD TO {shard}")
+                cursor.execute(f"SET SHARD TO '{shard}'")
         return self.get_response(request)

--- a/pgml-dashboard/pgml_dashboard/settings.py
+++ b/pgml-dashboard/pgml_dashboard/settings.py
@@ -13,7 +13,6 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 from pathlib import Path
 import os
 import mimetypes
-import json
 
 import dotenv
 

--- a/pgml-dashboard/pgml_dashboard/settings.py
+++ b/pgml-dashboard/pgml_dashboard/settings.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 from pathlib import Path
 import os
 import mimetypes
+import json
 
 import dotenv
 
@@ -73,6 +74,7 @@ MIDDLEWARE = [
     "request.middleware.RequestMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "app.middleware.MultiTenantMiddleware",
 ]
 
 ROOT_URLCONF = "pgml_dashboard.urls"
@@ -188,3 +190,11 @@ JWT_AUTH_ENABLED = os.environ.get("DJANGO_JWT_AUTH_ENABLED", "False") == "True"
 REQUEST_IGNORE_PATHS = [
     r"api/requests",
 ]
+
+# Connect to multiple PostgresML instances
+# if configured.
+MULTI_TENANT_CONFIG = {}
+MULTI_TENANT_CONFIG_PATH = os.environ.get("MULTI_TENANT_CONFIG_PATH")
+if MULTI_TENANT_CONFIG_PATH:
+    with open(MULTI_TENANT_CONFIG_PATH) as f:
+        MULTI_TENANT_CONFIG = json.load(f)

--- a/pgml-dashboard/pgml_dashboard/settings.py
+++ b/pgml-dashboard/pgml_dashboard/settings.py
@@ -66,6 +66,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "app.middleware.JwtAuthentcationMiddleware",
+    "app.middleware.MultiTenantMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -74,7 +75,6 @@ MIDDLEWARE = [
     "request.middleware.RequestMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "app.middleware.MultiTenantMiddleware",
 ]
 
 ROOT_URLCONF = "pgml_dashboard.urls"
@@ -117,7 +117,8 @@ DATABASES = {
         "HOST": database.hostname,
         "PORT": database.port,
         "SCHEMA": "pgml",
-    }
+        "CONN_MAX_AGE": 60,
+    },
 }
 
 # Password validation
@@ -190,11 +191,3 @@ JWT_AUTH_ENABLED = os.environ.get("DJANGO_JWT_AUTH_ENABLED", "False") == "True"
 REQUEST_IGNORE_PATHS = [
     r"api/requests",
 ]
-
-# Connect to multiple PostgresML instances
-# if configured.
-MULTI_TENANT_CONFIG = {}
-MULTI_TENANT_CONFIG_PATH = os.environ.get("MULTI_TENANT_CONFIG_PATH")
-if MULTI_TENANT_CONFIG_PATH:
-    with open(MULTI_TENANT_CONFIG_PATH) as f:
-        MULTI_TENANT_CONFIG = json.load(f)


### PR DESCRIPTION
1. Add `MultiTenantMiddleware` to be able to use multiple databases proxied by PgCat.
2. Enable persistent database connections.