### PR TITLE
More features from python going into Rust

### DIFF
--- a/pgml-extension/pgml_rust/sql/schema.sql
+++ b/pgml-extension/pgml_rust/sql/schema.sql
@@ -1,7 +1,75 @@
 CREATE SCHEMA IF NOT EXISTS pgml_rust;
 
+--- 
+--- Track of updates to data
+---
+CREATE OR REPLACE FUNCTION pgml_rust.auto_updated_at(tbl regclass) 
+RETURNS VOID 
+AS $$
+    DECLARE name_parts TEXT[];
+    DECLARE name TEXT; 
+BEGIN
+    name_parts := string_to_array(tbl::TEXT, '.');
+    name := name_parts[array_upper(name_parts, 1)];
+
+    EXECUTE format('DROP TRIGGER IF EXISTS %s_auto_updated_at ON %s', name, tbl);
+    EXECUTE format('CREATE TRIGGER %s_auto_updated_at BEFORE UPDATE ON %s
+                    FOR EACH ROW EXECUTE PROCEDURE pgml_rust.set_updated_at()', name, tbl);
+END;
+$$
+LANGUAGE plpgsql;
+
+
+---
+--- Called via trigger whenever a row changes
+---
+CREATE OR REPLACE FUNCTION pgml_rust.set_updated_at() 
+RETURNS TRIGGER 
+AS $$
+BEGIN
+    IF (
+        NEW IS DISTINCT FROM OLD
+        AND NEW.updated_at IS NOT DISTINCT FROM OLD.updated_at
+    ) THEN
+        NEW.updated_at := clock_timestamp();
+    END IF;
+    RETURN NEW;
+END;
+$$
+LANGUAGE plpgsql;
+
+---
+--- Projects organize work
+---
+CREATE TABLE IF NOT EXISTS pgml_rust.projects(
+	id BIGSERIAL PRIMARY KEY,
+	name TEXT NOT NULL UNIQUE,
+	task TEXT NOT NULL,
+	created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT clock_timestamp(),
+	updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT clock_timestamp()
+);
+SELECT pgml_rust.auto_updated_at('pgml_rust.projects');
+
+
 CREATE TABLE IF NOT EXISTS pgml_rust.models (
 	id BIGSERIAL PRIMARY KEY,
+	project_id BIGINT NOT NULL REFERENCES pgml_rust.projects(id),
 	algorithm VARCHAR,
 	data BYTEA
 );
+
+---
+--- Deployments determine which model is live
+---
+CREATE TABLE IF NOT EXISTS pgml_rust.deployments(
+	id BIGSERIAL PRIMARY KEY,
+	project_id BIGINT NOT NULL,
+	model_id BIGINT NOT NULL,
+	strategy TEXT NOT NULL,
+	created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT clock_timestamp(),
+	CONSTRAINT project_id_fk FOREIGN KEY(project_id) REFERENCES pgml_rust.projects(id),
+	CONSTRAINT model_id_fk FOREIGN KEY(model_id) REFERENCES pgml_rust.models(id)
+);
+CREATE INDEX IF NOT EXISTS deployments_project_id_created_at_idx ON pgml_rust.deployments(project_id);
+CREATE INDEX IF NOT EXISTS deployments_model_id_created_at_idx ON pgml_rust.deployments(model_id);
+SELECT pgml_rust.auto_updated_at('pgml_rust.deployments');

--- a/pgml-extension/pgml_rust/src/lib.rs
+++ b/pgml-extension/pgml_rust/src/lib.rs
@@ -20,168 +20,356 @@ extension_sql_file!(
 // This space here is connection-specific.
 static MODELS: Lazy<Mutex<HashMap<i64, Vec<u8>>>> = Lazy::new(|| Mutex::new(HashMap::new()));
 
-/// Main training function to train an XGBoost model on a dataset.
-///
-/// Example:
-///
-/// ```
-/// SELECT * FROM pgml_train('pgml_rust.diabetes', ARRAY['age', 'sex'], 'target');
-#[pg_extern]
-fn pgml_rust_train(relation_name: String, features: Vec<String>, label: String) -> i64 {
-    let features = features
-        .into_iter()
-        .map(|column| format!("CAST({} AS REAL)", column))
-        .collect::<Vec<String>>();
-
-    let query = format!(
-        "SELECT {}, CAST({} AS REAL) FROM {} ORDER BY RANDOM()",
-        features.clone().join(", "),
-        label,
-        relation_name
-    );
-
-    let (mut x, mut y, mut num_rows) = (vec![], vec![], 0);
-
-    info!("Fetching data: {}", query);
-
-    Spi::connect(|client| {
-        client.select(&query, None, None).for_each(|row| {
-            // Postgres arrays start at one and for some reason
-            // so do these tuple indexes.
-            for i in 1..features.len() + 1 {
-                x.push(row[i].value::<f32>().unwrap_or(0 as f32));
-            }
-            y.push(row[features.len() + 1].value::<f32>().unwrap_or(0 as f32));
-            num_rows += 1;
-        });
-
-        Ok(Some(()))
-    });
-
-    let mut dtrain = DMatrix::from_dense(&x, num_rows).unwrap();
-    dtrain.set_labels(&y).unwrap();
-
-    // configure objectives, metrics, etc.
-    let learning_params = parameters::learning::LearningTaskParametersBuilder::default()
-        .objective(parameters::learning::Objective::RegLinear)
-        .build()
-        .unwrap();
-
-    // configure the tree-based learning model's parameters
-    let tree_params = parameters::tree::TreeBoosterParametersBuilder::default()
-        .max_depth(2)
-        .eta(1.0)
-        .build()
-        .unwrap();
-
-    // overall configuration for Booster
-    let booster_params = parameters::BoosterParametersBuilder::default()
-        .booster_type(parameters::BoosterType::Tree(tree_params))
-        .learning_params(learning_params)
-        .verbose(true)
-        .build()
-        .unwrap();
-
-    // specify datasets to evaluate against during training
-    // let evaluation_sets = &[(&dtrain, "train"), (&dtest, "test")];
-
-    // overall configuration for training/evaluation
-    let params = parameters::TrainingParametersBuilder::default()
-        .dtrain(&dtrain) // dataset to train with
-        .boost_rounds(2) // number of training iterations
-        .booster_params(booster_params) // model parameters
-        // .evaluation_sets(Some(evaluation_sets)) // optional datasets to evaluate against in each iteration
-        .build()
-        .unwrap();
-
-    // train model, and print evaluation data
-    let bst = Booster::train(&params).unwrap();
-
-    let r: i64 = rand::random();
-    let path = format!("/tmp/pgml_rust_{}.bin", r);
-
-    bst.save(Path::new(&path)).unwrap();
-
-    let bytes = fs::read(&path).unwrap();
-
-    Spi::get_one_with_args::<i64>(
-        "INSERT INTO pgml_rust.models (id, algorithm, data) VALUES (DEFAULT, 'xgboost', $1) RETURNING id",
-        vec![
-            (PgBuiltInOids::BYTEAOID.oid(), bytes.into_datum())
-        ]
-    ).unwrap()
-}
-
 /// Predict a novel data point using the model created by pgml_train.
 ///
 /// Example:
 /// ```
 /// SELECT * FROM pgml_predict(ARRAY[1, 2, 3]);
-#[pg_extern]
-fn pgml_rust_predict(model_id: i64, features: Vec<f32>) -> f32 {
-    let mut guard = MODELS.lock().unwrap();
+#[pg_schema]
+mod pgml_rust {
+    use super::*;
 
-    match guard.get(&model_id) {
-        Some(data) => {
-            let bst = Booster::load_buffer(&data).unwrap();
-            let dmat = DMatrix::from_dense(&features, 1).unwrap();
+    #[derive(PostgresEnum, Copy, Clone)]
+    #[allow(non_camel_case_types)]
+    enum Algorithm {
+        xgboost,
+    }
 
-            bst.predict(&dmat).unwrap()[0]
+    #[derive(PostgresEnum, Copy, Clone, PartialEq, Debug)]
+    #[allow(non_camel_case_types)]
+    enum ProjectTask {
+        regression,
+        classification,
+    }
+
+    impl PartialEq<String> for ProjectTask {
+        fn eq(&self, other: &String) -> bool {
+            match *self {
+                ProjectTask::regression => "regression" == other,
+                ProjectTask::classification => "classification" == other,
+            }
+        }
+    }
+
+    impl ProjectTask {
+        pub fn to_string(&self) -> String {
+            match *self {
+                ProjectTask::regression => "regression".to_string(),
+                ProjectTask::classification => "classification".to_string(),
+            }
+        }
+    }
+
+    /// Main training function to train an XGBoost model on a dataset.
+    ///
+    /// Example:
+    ///
+    /// ```
+    /// SELECT * FROM pgml_rust.train('pgml_rust.diabetes', ARRAY['age', 'sex'], 'target');
+    #[pg_extern]
+    fn train(
+        project_name: String,
+        task: ProjectTask,
+        relation_name: String,
+        label: String,
+        _algorithm: Algorithm,
+        hyperparams: Json,
+    ) -> i64 {
+        let parts = relation_name
+            .split(".")
+            .map(|name| name.to_string())
+            .collect::<Vec<String>>();
+
+        let (schema_name, table_name) = match parts.len() {
+            1 => (String::from("public"), parts[0].clone()),
+            2 => (parts[0].clone(), parts[1].clone()),
+            _ => error!(
+                "Relation name {} is not parsable into schema name and table name",
+                relation_name
+            ),
+        };
+
+        let (mut x, mut y, mut num_rows) = (vec![], vec![], 0);
+
+        let hyperparams = hyperparams.0;
+
+        let (projet_id, project_task) = Spi::get_two_with_args::<i64, String>("INSERT INTO pgml_rust.projects (name, task) VALUES ($1, $2) ON CONFLICT (name) DO UPDATE SET name = $1 RETURNING id, task",
+            vec![
+                (PgBuiltInOids::TEXTOID.oid(), project_name.clone().into_datum()),
+                (PgBuiltInOids::TEXTOID.oid(), task.to_string().into_datum()),
+            ]);
+
+        let (projet_id, project_task) = (projet_id.unwrap(), project_task.unwrap());
+
+        if project_task != task.to_string() {
+            error!(
+                "Project '{}' already exists with a different objective: {}",
+                project_name, project_task
+            );
         }
 
-        None => {
-            match Spi::get_one_with_args::<Vec<u8>>(
-                "SELECT data FROM pgml_rust.models WHERE id = $1",
-                vec![(PgBuiltInOids::INT8OID.oid(), model_id.into_datum())],
-            ) {
-                Some(data) => {
-                    info!("Model cache cold, loading from \"pgml_rust\".\"models\"");
+        Spi::connect(|client| {
+            let mut features = Vec::new();
 
-                    guard.insert(model_id, data.clone());
-                    let bst = Booster::load_buffer(&data).unwrap();
-                    let dmat = DMatrix::from_dense(&features, 1).unwrap();
+            client.select("SELECT CAST(column_name AS TEXT) FROM information_schema.columns WHERE table_name = $1 AND table_schema = $2 AND column_name != $3",
+                None,
+                Some(vec![
+                    (PgBuiltInOids::TEXTOID.oid(), table_name.clone().into_datum()),
+                    (PgBuiltInOids::TEXTOID.oid(), schema_name.into_datum()),
+                    (PgBuiltInOids::TEXTOID.oid(), label.clone().into_datum()),
+                ]))
+            .for_each(|row| {
+                features.push(row[1].value::<String>().unwrap())
+            });
 
-                    bst.predict(&dmat).unwrap()[0]
+            let features = features
+                .into_iter()
+                .map(|column| format!("CAST({} AS REAL)", column))
+                .collect::<Vec<String>>();
+
+            let query = format!(
+                "SELECT {}, CAST({} AS REAL) FROM {} ORDER BY RANDOM()",
+                features.clone().join(", "),
+                label,
+                relation_name
+            );
+
+            info!("Fetching data: {}", query);
+
+            client.select(&query, None, None).for_each(|row| {
+                // Postgres arrays start at one and for some reason
+                // so do these tuple indexes.
+                for i in 1..features.len() + 1 {
+                    x.push(row[i].value::<f32>().unwrap_or(0 as f32));
                 }
-                None => {
-                    error!("No model with id = {} found", model_id);
+                y.push(row[features.len() + 1].value::<f32>().unwrap_or(0 as f32));
+                num_rows += 1;
+            });
+
+            Ok(Some(()))
+        });
+
+        let mut dtrain = DMatrix::from_dense(&x, num_rows).unwrap();
+        dtrain.set_labels(&y).unwrap();
+
+        // configure objectives, metrics, etc.
+        let learning_params = parameters::learning::LearningTaskParametersBuilder::default()
+            .objective(match task {
+                ProjectTask::regression => xgboost::parameters::learning::Objective::RegLinear,
+                ProjectTask::classification => {
+                    xgboost::parameters::learning::Objective::RegLogistic
+                }
+            })
+            .build()
+            .unwrap();
+
+        // configure the tree-based learning model's parameters
+        let tree_params = parameters::tree::TreeBoosterParametersBuilder::default()
+            .max_depth(match hyperparams.get("max_depth") {
+                Some(value) => value.as_u64().unwrap_or(2) as u32,
+                None => 2,
+            })
+            .eta(0.3)
+            .build()
+            .unwrap();
+
+        // overall configuration for Booster
+        let booster_params = parameters::BoosterParametersBuilder::default()
+            .booster_type(parameters::BoosterType::Tree(tree_params))
+            .learning_params(learning_params)
+            .verbose(true)
+            .build()
+            .unwrap();
+
+        // specify datasets to evaluate against during training
+        // let evaluation_sets = &[(&dtrain, "train"), (&dtest, "test")];
+
+        // overall configuration for training/evaluation
+        let params = parameters::TrainingParametersBuilder::default()
+            .dtrain(&dtrain) // dataset to train with
+            .boost_rounds(match hyperparams.get("n_estimators") {
+                Some(value) => value.as_u64().unwrap_or(2) as u32,
+                None => 2,
+            }) // number of training iterations
+            .booster_params(booster_params) // model parameters
+            // .evaluation_sets(Some(evaluation_sets)) // optional datasets to evaluate against in each iteration
+            .build()
+            .unwrap();
+
+        // train model, and print evaluation data
+        let bst = match Booster::train(&params) {
+            Ok(bst) => bst,
+            Err(err) => error!("{}", err),
+        };
+
+        let r: u64 = rand::random();
+        let path = format!("/tmp/pgml_rust_{}.bin", r);
+
+        bst.save(Path::new(&path)).unwrap();
+
+        let bytes = fs::read(&path).unwrap();
+
+        let model_id = Spi::get_one_with_args::<i64>(
+            "INSERT INTO pgml_rust.models (id, project_id, algorithm, data) VALUES (DEFAULT, $1, 'xgboost', $2) RETURNING id",
+            vec![
+                (PgBuiltInOids::INT8OID.oid(), projet_id.into_datum()),
+                (PgBuiltInOids::BYTEAOID.oid(), bytes.into_datum())
+            ]
+        ).unwrap();
+
+        Spi::get_one_with_args::<i64>(
+            "INSERT INTO pgml_rust.deployments (project_id, model_id, strategy) VALUES ($1, $2, 'last_trained') RETURNING id",
+            vec![
+                (PgBuiltInOids::INT8OID.oid(), projet_id.into_datum()),
+                (PgBuiltInOids::INT8OID.oid(), model_id.into_datum()),
+            ]
+        );
+
+        model_id
+    }
+
+    #[pg_extern]
+    fn predict(project_name: String, features: Vec<f32>) -> f32 {
+        let model_id = Spi::get_one_with_args(
+            "SELECT model_id
+            FROM pgml_rust.deployments
+            INNER JOIN pgml_rust.projects ON
+            pgml_rust.deployments.project_id = pgml_rust.projects.id
+            AND pgml_rust.projects.name = $1
+            ORDER BY pgml_rust.deployments.id DESC LIMIT 1",
+            vec![(
+                PgBuiltInOids::TEXTOID.oid(),
+                project_name.clone().into_datum(),
+            )],
+        );
+
+        match model_id {
+            Some(model_id) => model_predict(model_id, features),
+            None => error!("Project '{}' doesn't exist", project_name),
+        }
+    }
+
+    #[pg_extern]
+    fn model_predict(model_id: i64, features: Vec<f32>) -> f32 {
+        let mut guard = MODELS.lock().unwrap();
+
+        match guard.get(&model_id) {
+            Some(data) => {
+                let bst = Booster::load_buffer(&data).unwrap();
+                let dmat = DMatrix::from_dense(&features, 1).unwrap();
+
+                bst.predict(&dmat).unwrap()[0]
+            }
+
+            None => {
+                match Spi::get_one_with_args::<Vec<u8>>(
+                    "SELECT data FROM pgml_rust.models WHERE id = $1",
+                    vec![(PgBuiltInOids::INT8OID.oid(), model_id.into_datum())],
+                ) {
+                    Some(data) => {
+                        info!("Model cache cold, loading from \"pgml_rust\".\"models\"");
+
+                        guard.insert(model_id, data.clone());
+                        let bst = Booster::load_buffer(&data).unwrap();
+                        let dmat = DMatrix::from_dense(&features, 1).unwrap();
+
+                        bst.predict(&dmat).unwrap()[0]
+                    }
+                    None => {
+                        error!("No model with id = {} found", model_id);
+                    }
                 }
             }
         }
     }
-}
 
-/// Load a model into the extension. The model is saved in our table,
-/// which is then replicated to replicas for load balancing.
-#[pg_extern]
-fn pgml_rust_load_model(data: Vec<u8>) -> i64 {
-    Spi::get_one_with_args::<i64>(
-        "INSERT INTO pgml_rust.models (id, algorithm, data) VALUES (DEFAULT, 'xgboost', $1) RETURNING id",
-        vec![
-            (PgBuiltInOids::BYTEAOID.oid(), data.into_datum()),
-        ],
-    ).unwrap()
-}
+    #[pg_extern]
+    fn model_predict_batch(model_id: i64, features: Vec<f32>, num_rows: i32) -> Vec<f32> {
+        let mut guard = MODELS.lock().unwrap();
 
-/// Load a model into the extension from a file.
-#[pg_extern]
-fn pgml_rust_load_model_from_file(path: String) -> i64 {
-    let bytes = fs::read(&path).unwrap();
+        if num_rows < 0 {
+            error!("Number of rows has to be greater than 0");
+        }
 
-    Spi::get_one_with_args::<i64>(
-        "INSERT INTO pgml_rust.models (id, algorithm, data) VALUES (DEFAULT, 'xgboost', $1) RETURNING id",
-        vec![
-            (PgBuiltInOids::BYTEAOID.oid(), bytes.into_datum()),
-        ],
-    ).unwrap()
-}
+        match guard.get(&model_id) {
+            Some(data) => {
+                let bst = Booster::load_buffer(&data).unwrap();
+                let dmat = DMatrix::from_dense(&features, num_rows as usize).unwrap();
 
-#[pg_extern]
-fn pgml_rust_delete_model(model_id: i64) {
-    Spi::run(&format!(
-        "DELETE FROM pgml_rust.models WHERE id = {}",
-        model_id
-    ));
+                bst.predict(&dmat).unwrap()
+            }
+
+            None => {
+                match Spi::get_one_with_args::<Vec<u8>>(
+                    "SELECT data FROM pgml_rust.models WHERE id = $1",
+                    vec![(PgBuiltInOids::INT8OID.oid(), model_id.into_datum())],
+                ) {
+                    Some(data) => {
+                        info!("Model cache cold, loading from \"pgml_rust\".\"models\"");
+
+                        guard.insert(model_id, data.clone());
+                        let bst = Booster::load_buffer(&data).unwrap();
+                        let dmat = DMatrix::from_dense(&features, num_rows as usize).unwrap();
+
+                        bst.predict(&dmat).unwrap()
+                    }
+                    None => {
+                        error!("No model with id = {} found", model_id);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Load a model into the extension. The model is saved in our table,
+    /// which is then replicated to replicas for load balancing.
+    #[pg_extern]
+    fn load_model(data: Vec<u8>) -> i64 {
+        Spi::get_one_with_args::<i64>(
+            "INSERT INTO pgml_rust.models (id, algorithm, data) VALUES (DEFAULT, 'xgboost', $1) RETURNING id",
+            vec![
+                (PgBuiltInOids::BYTEAOID.oid(), data.into_datum()),
+            ],
+        ).unwrap()
+    }
+
+    /// Load a model into the extension from a file.
+    #[pg_extern]
+    fn load_model_from_file(path: String) -> i64 {
+        let bytes = fs::read(&path).unwrap();
+
+        Spi::get_one_with_args::<i64>(
+            "INSERT INTO pgml_rust.models (id, algorithm, data) VALUES (DEFAULT, 'xgboost', $1) RETURNING id",
+            vec![
+                (PgBuiltInOids::BYTEAOID.oid(), bytes.into_datum()),
+            ],
+        ).unwrap()
+    }
+
+    #[pg_extern]
+    fn delete_model(model_id: i64) {
+        Spi::run(&format!(
+            "DELETE FROM pgml_rust.models WHERE id = {}",
+            model_id
+        ));
+    }
+
+    #[pg_extern]
+    fn dump_model(model_id: i64) -> String {
+        let bytes = Spi::get_one_with_args::<Vec<u8>>(
+            "SELECT data FROM pgml_rust.models WHERE id = $1",
+            vec![(PgBuiltInOids::INT8OID.oid(), model_id.into_datum())],
+        );
+
+        match bytes {
+            Some(bytes) => match Booster::load_buffer(&bytes) {
+                Ok(bst) => bst.dump_model(true, None).unwrap(),
+                Err(err) => error!("Could not load XGBoost model: {:?}", err),
+            },
+
+            None => error!("Model with id = {} does not exist", model_id),
+        }
+    }
 }
 
 #[cfg(any(test, feature = "pg_test"))]


### PR DESCRIPTION
1. Projects (just like in Python)
2. Deployments (only latest_trained for now, no metrics yet).
3. `predict` like in Python,
4. Two hyper-parameters for XGBoost: `n_estimators` and `max_depth`.
5. Batch predictions.
6. Dump model to debug XGBoost tree / confirm hyper parameters.


### Batch predictions

```sql
WITH t1 AS (SELECT * FROM pgml_rust.diabetes LIMIT 5),
t2 AS (
	SELECT array_agg(ARRAY[t1.age, t1.sex]) features FROM t1
)
select pgml_rust.model_predict_batch(1, array_agg(c), 5)
from (
  select unnest(features)
  from t2
) as dt(c);


```