### PR TITLE
Fix Scikit and last snapshot

### DIFF
--- a/pgml-extension/pgml_rust/src/api.rs
+++ b/pgml-extension/pgml_rust/src/api.rs
@@ -104,9 +104,11 @@ fn train(
         Some(project) => project,
         None => Project::create(project_name, task.unwrap()),
     };
+
     if task.is_some() && task.unwrap() != project.task {
         error!("Project `{:?}` already exists with a different task: `{:?}`. Create a new project instead.", project.name, project.task);
     }
+
     let snapshot = match relation_name {
         None => project.last_snapshot().expect("You must pass a `relation_name` and `y_column_name` to snapshot the first time you train a model."),
         Some(relation_name) => Snapshot::create(relation_name, y_column_name.expect("You must pass a `y_column_name` when you pass a `relation_name`"), test_size, test_sampling)
@@ -116,7 +118,6 @@ fn train(
     // let algorithm = Model.algorithm_from_name_and_task(algorithm, task);
     // if "random_state" in algorithm().get_params() and "random_state" not in hyperparams:
     //     hyperparams["random_state"] = 0
-
     let model = Model::create(
         &project,
         &snapshot,

--- a/pgml-extension/pgml_rust/src/orm/model.rs
+++ b/pgml-extension/pgml_rust/src/orm/model.rs
@@ -61,7 +61,7 @@ impl Model {
             let result = client.select("
           INSERT INTO pgml.models (project_id, snapshot_id, algorithm, runtime, hyperparams, status, search, search_params, search_args, num_features) 
           VALUES ($1, $2, cast($3 AS pgml.algorithm), cast($4 AS pgml.runtime), $5, cast($6 as pgml.status), $7, $8, $9, $10) 
-          RETURNING id, project_id, snapshot_id, algorithm::text, runtime, hyperparams, status, metrics, search, search_params, search_args, created_at, updated_at;",
+          RETURNING id, project_id, snapshot_id, algorithm, runtime, hyperparams, status, metrics, search, search_params, search_args, created_at, updated_at;",
               Some(1),
               Some(vec![
                   (PgBuiltInOids::INT8OID.oid(), project.id.into_datum()),

--- a/pgml-extension/pgml_rust/src/orm/model.rs
+++ b/pgml-extension/pgml_rust/src/orm/model.rs
@@ -61,7 +61,7 @@ impl Model {
             let result = client.select("
           INSERT INTO pgml.models (project_id, snapshot_id, algorithm, runtime, hyperparams, status, search, search_params, search_args, num_features) 
           VALUES ($1, $2, cast($3 AS pgml.algorithm), cast($4 AS pgml.runtime), $5, cast($6 as pgml.status), $7, $8, $9, $10) 
-          RETURNING id, project_id, snapshot_id, algorithm, runtime, hyperparams, status, metrics, search, search_params, search_args, created_at, updated_at;",
+          RETURNING id, project_id, snapshot_id, algorithm::text, runtime, hyperparams, status, metrics, search, search_params, search_args, created_at, updated_at;",
               Some(1),
               Some(vec![
                   (PgBuiltInOids::INT8OID.oid(), project.id.into_datum()),


### PR DESCRIPTION
Tested by running the `tests/regression.sql` test suite.

1. Fix Scikit performance regression.
2. Fix last snapshot crashing because of enum parsing.