### PR TITLE
Deployment strategy & end-to-end tests

### DIFF
--- a/pgml-extension/pgml_rust/src/api.rs
+++ b/pgml-extension/pgml_rust/src/api.rs
@@ -98,7 +98,6 @@ fn train(
         name!(project, String),
         name!(task, String),
         name!(algorithm, String),
-        name!(model_id, i64),
         name!(deployed, bool),
     ),
 > {
@@ -198,7 +197,6 @@ fn train(
         project.name,
         project.task.to_string(),
         model.algorithm.to_string(),
-        model.id,
         deploy,
     )]
     .into_iter()
@@ -415,7 +413,7 @@ mod tests {
         info!("Data directory: {}", setting.unwrap());
 
         for runtime in [Runtime::python, Runtime::rust] {
-            let result: Vec<(String, String, String, i64, bool)> = train(
+            let result: Vec<(String, String, String, bool)> = train(
                 "Test project",
                 Some(Task::regression),
                 Some("pgml.diabetes"),
@@ -436,7 +434,7 @@ mod tests {
             assert_eq!(result[0].0, String::from("Test project"));
             assert_eq!(result[0].1, String::from("regression"));
             assert_eq!(result[0].2, String::from("linear"));
-            assert_eq!(result[0].4, false);
+            assert_eq!(result[0].3, false);
         }
     }
 
@@ -452,7 +450,7 @@ mod tests {
         info!("Data directory: {}", setting.unwrap());
 
         for runtime in [Runtime::python, Runtime::rust] {
-            let result: Vec<(String, String, String, i64, bool)> = train(
+            let result: Vec<(String, String, String, bool)> = train(
                 "Test project 2",
                 Some(Task::classification),
                 Some("pgml.digits"),
@@ -473,7 +471,7 @@ mod tests {
             assert_eq!(result[0].0, String::from("Test project 2"));
             assert_eq!(result[0].1, String::from("classification"));
             assert_eq!(result[0].2, String::from("xgboost"));
-            assert_eq!(result[0].4, false);
+            assert_eq!(result[0].3, false);
         }
     }
 }

--- a/pgml-extension/pgml_rust/src/api.rs
+++ b/pgml-extension/pgml_rust/src/api.rs
@@ -98,6 +98,7 @@ fn train(
         name!(project, String),
         name!(task, String),
         name!(algorithm, String),
+        name!(model_id, i64),
         name!(deployed, bool),
     ),
 > {
@@ -197,6 +198,7 @@ fn train(
         project.name,
         project.task.to_string(),
         model.algorithm.to_string(),
+        model.id,
         deploy,
     )]
     .into_iter()
@@ -413,7 +415,7 @@ mod tests {
         info!("Data directory: {}", setting.unwrap());
 
         for runtime in [Runtime::python, Runtime::rust] {
-            let result: Vec<(String, String, String, bool)> = train(
+            let result: Vec<(String, String, String, i64, bool)> = train(
                 "Test project",
                 Some(Task::regression),
                 Some("pgml.diabetes"),
@@ -434,7 +436,7 @@ mod tests {
             assert_eq!(result[0].0, String::from("Test project"));
             assert_eq!(result[0].1, String::from("regression"));
             assert_eq!(result[0].2, String::from("linear"));
-            assert_eq!(result[0].3, false);
+            assert_eq!(result[0].4, false);
         }
     }
 
@@ -450,7 +452,7 @@ mod tests {
         info!("Data directory: {}", setting.unwrap());
 
         for runtime in [Runtime::python, Runtime::rust] {
-            let result: Vec<(String, String, String, bool)> = train(
+            let result: Vec<(String, String, String, i64, bool)> = train(
                 "Test project 2",
                 Some(Task::classification),
                 Some("pgml.digits"),
@@ -471,7 +473,7 @@ mod tests {
             assert_eq!(result[0].0, String::from("Test project 2"));
             assert_eq!(result[0].1, String::from("classification"));
             assert_eq!(result[0].2, String::from("xgboost"));
-            assert_eq!(result[0].3, false);
+            assert_eq!(result[0].4, false);
         }
     }
 }


### PR DESCRIPTION
1. Add `automatic_deploy` parameter to the `pgml.train` function, set to true by default. If true, the deployment logic will run and deploy a better model, if one is trained. If set to false, the trained model will not be deployed.
2. Add a couple end-to-end regression and classification tests using Python and Rust runtimes.

The addition of `automatic_deploy` option has two reasons, one is better than the other:

1. In production, automatic deploys may not be desirable even if the model is better in training. Sometimes a user would want to just train a model and see what happens without any consequences to the production app.
2. Enabling shared memory in end-to-end tests is a two-step process which may not be doable automatically. Until we can figure that out, and since only deployments use shared memory, end-to-end tests in Rust can avoid using shared memory this way.

```
pgml=# select * from pgml.train('test 2', 'regression', 'pgml.diabetes', 'target', runtime => 'rust', automatic_deploy => true);
[...]
 project |    task    | algorithm | deployed
---------+------------+-----------+----------
 test 2  | regression | linear    | t
(1 row)
```