### PR TITLE
Enable Scikit by default but make it optional

### DIFF
--- a/pgml-extension/Cargo.toml
+++ b/pgml-extension/Cargo.toml
@@ -7,14 +7,14 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [features]
-default = ["pg13", "sklearn"]
+default = ["pg13", "python"]
 pg10 = ["pgx/pg10", "pgx-tests/pg10" ]
 pg11 = ["pgx/pg11", "pgx-tests/pg11" ]
 pg12 = ["pgx/pg12", "pgx-tests/pg12" ]
 pg13 = ["pgx/pg13", "pgx-tests/pg13" ]
 pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
-sklearn = ["pyo3"]
+python = ["pyo3"]
 
 [dependencies]
 pgx = "=0.4.5"

--- a/pgml-extension/Cargo.toml
+++ b/pgml-extension/Cargo.toml
@@ -7,13 +7,14 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [features]
-default = ["pg13"]
+default = ["pg13", "sklearn"]
 pg10 = ["pgx/pg10", "pgx-tests/pg10" ]
 pg11 = ["pgx/pg11", "pgx-tests/pg11" ]
 pg12 = ["pgx/pg12", "pgx-tests/pg12" ]
 pg13 = ["pgx/pg13", "pgx-tests/pg13" ]
 pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
+sklearn = ["pyo3"]
 
 [dependencies]
 pgx = "=0.4.5"
@@ -30,7 +31,7 @@ serde = { version = "1.0.2" }
 serde_json = { version = "1.0.85", features = ["preserve_order"] }
 rmp-serde = { version = "1.1.0" }
 typetag = "0.2"
-pyo3 = { version = "0.17", features = ["auto-initialize"] }
+pyo3 = { version = "0.17", features = ["auto-initialize"], optional = true }
 heapless = "0.7.13"
 lightgbm = { git="https://github.com/postgresml/lightgbm-rs" }
 parking_lot = "0.12"

--- a/pgml-extension/src/api.rs
+++ b/pgml-extension/src/api.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 
 use once_cell::sync::Lazy;
 use pgx::*;
+#[cfg(feature = "sklearn")]
 use pyo3::prelude::*;
 use serde_json::json;
 
@@ -28,6 +29,7 @@ pub extern "C" fn _PG_init() {
     pg_shmem_init!(PROJECT_ID_TO_DEPLOYED_MODEL_ID);
 }
 
+#[cfg(feature = "sklearn")]
 #[pg_extern]
 pub fn validate_python_dependencies() {
     Python::with_gil(|py| {
@@ -54,6 +56,11 @@ pub fn validate_python_dependencies() {
     );
 }
 
+#[cfg(not(feature = "sklearn"))]
+#[pg_extern]
+pub fn validate_python_dependencies() {}
+
+#[cfg(feature = "sklearn")]
 #[pg_extern]
 pub fn sklearn_version() -> String {
     let mut version = String::new();
@@ -66,6 +73,13 @@ pub fn sklearn_version() -> String {
     version
 }
 
+#[cfg(not(feature = "sklearn"))]
+#[pg_extern]
+pub fn sklearn_version() -> String {
+    String::from("Scikit-learn is not installed, recompile with `--features sklearn`")
+}
+
+#[cfg(feature = "sklearn")]
 #[pg_extern]
 fn python_version() -> String {
     let mut version = String::new();
@@ -76,6 +90,12 @@ fn python_version() -> String {
     });
 
     version
+}
+
+#[cfg(not(feature = "sklearn"))]
+#[pg_extern]
+pub fn python_version() -> String {
+    String::from("Python is not installed, recompile with `--features sklearn`")
 }
 
 #[pg_extern]
@@ -429,6 +449,7 @@ fn model_predict_batch(model_id: i64, features: Vec<f32>) -> Vec<f32> {
     estimator.predict_batch(&features)
 }
 
+#[cfg(feature = "sklearn")]
 #[pg_extern(name = "transform")]
 pub fn transform_json(
     task: JsonB,
@@ -440,6 +461,7 @@ pub fn transform_json(
     ))
 }
 
+#[cfg(feature = "sklearn")]
 #[pg_extern(name = "transform")]
 pub fn transform_string(
     task: String,

--- a/pgml-extension/src/api.rs
+++ b/pgml-extension/src/api.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 
 use once_cell::sync::Lazy;
 use pgx::*;
-#[cfg(feature = "sklearn")]
+#[cfg(feature = "python")]
 use pyo3::prelude::*;
 use serde_json::json;
 
@@ -29,7 +29,7 @@ pub extern "C" fn _PG_init() {
     pg_shmem_init!(PROJECT_ID_TO_DEPLOYED_MODEL_ID);
 }
 
-#[cfg(feature = "sklearn")]
+#[cfg(feature = "python")]
 #[pg_extern]
 pub fn validate_python_dependencies() {
     Python::with_gil(|py| {
@@ -56,11 +56,11 @@ pub fn validate_python_dependencies() {
     );
 }
 
-#[cfg(not(feature = "sklearn"))]
+#[cfg(not(feature = "python"))]
 #[pg_extern]
 pub fn validate_python_dependencies() {}
 
-#[cfg(feature = "sklearn")]
+#[cfg(feature = "python")]
 #[pg_extern]
 pub fn sklearn_version() -> String {
     let mut version = String::new();
@@ -73,13 +73,13 @@ pub fn sklearn_version() -> String {
     version
 }
 
-#[cfg(not(feature = "sklearn"))]
+#[cfg(not(feature = "python"))]
 #[pg_extern]
 pub fn sklearn_version() -> String {
     String::from("Scikit-learn is not installed, recompile with `--features sklearn`")
 }
 
-#[cfg(feature = "sklearn")]
+#[cfg(feature = "python")]
 #[pg_extern]
 fn python_version() -> String {
     let mut version = String::new();
@@ -92,7 +92,7 @@ fn python_version() -> String {
     version
 }
 
-#[cfg(not(feature = "sklearn"))]
+#[cfg(not(feature = "python"))]
 #[pg_extern]
 pub fn python_version() -> String {
     String::from("Python is not installed, recompile with `--features sklearn`")
@@ -449,7 +449,7 @@ fn model_predict_batch(model_id: i64, features: Vec<f32>) -> Vec<f32> {
     estimator.predict_batch(&features)
 }
 
-#[cfg(feature = "sklearn")]
+#[cfg(feature = "python")]
 #[pg_extern(name = "transform")]
 pub fn transform_json(
     task: JsonB,
@@ -461,7 +461,7 @@ pub fn transform_json(
     ))
 }
 
-#[cfg(feature = "sklearn")]
+#[cfg(feature = "python")]
 #[pg_extern(name = "transform")]
 pub fn transform_string(
     task: String,

--- a/pgml-extension/src/api.rs
+++ b/pgml-extension/src/api.rs
@@ -76,7 +76,7 @@ pub fn sklearn_version() -> String {
 #[cfg(not(feature = "python"))]
 #[pg_extern]
 pub fn sklearn_version() -> String {
-    String::from("Scikit-learn is not installed, recompile with `--features sklearn`")
+    String::from("Scikit-learn is not installed, recompile with `--features python`")
 }
 
 #[cfg(feature = "python")]
@@ -95,7 +95,7 @@ fn python_version() -> String {
 #[cfg(not(feature = "python"))]
 #[pg_extern]
 pub fn python_version() -> String {
-    String::from("Python is not installed, recompile with `--features sklearn`")
+    String::from("Python is not installed, recompile with `--features python`")
 }
 
 #[pg_extern]

--- a/pgml-extension/src/bindings/mod.rs
+++ b/pgml-extension/src/bindings/mod.rs
@@ -1,8 +1,14 @@
 pub mod lightgbm;
 pub mod linfa;
+
+#[cfg(feature = "sklearn")]
 pub mod sklearn;
+
 pub mod smartcore;
+
+#[cfg(feature = "sklearn")]
 pub mod transformers;
+
 pub mod xgboost;
 
 use crate::orm::*;

--- a/pgml-extension/src/bindings/mod.rs
+++ b/pgml-extension/src/bindings/mod.rs
@@ -1,12 +1,12 @@
 pub mod lightgbm;
 pub mod linfa;
 
-#[cfg(feature = "sklearn")]
+#[cfg(feature = "python")]
 pub mod sklearn;
 
 pub mod smartcore;
 
-#[cfg(feature = "sklearn")]
+#[cfg(feature = "python")]
 pub mod transformers;
 
 pub mod xgboost;

--- a/pgml-extension/src/orm/file.rs
+++ b/pgml-extension/src/orm/file.rs
@@ -121,7 +121,7 @@ pub fn find_deployed_estimator_by_model_id(model_id: i64) -> Arc<Box<dyn Binding
 
         #[cfg(not(feature = "python"))]
         Runtime::python => {
-            error!("Python runtime not supported, recompile with `--features sklearn`")
+            error!("Python runtime not supported, recompile with `--features python`")
         }
     };
 

--- a/pgml-extension/src/orm/file.rs
+++ b/pgml-extension/src/orm/file.rs
@@ -48,10 +48,7 @@ pub fn find_deployed_estimator_by_model_id(model_id: i64) -> Arc<Box<dyn Binding
                     LIMIT 1
                 ",
                 Some(1),
-                Some(vec![(
-                    PgBuiltInOids::INT8OID.oid(),
-                    model_id.into_datum(),
-                )]),
+                Some(vec![(PgBuiltInOids::INT8OID.oid(), model_id.into_datum())]),
             )
             .first();
 
@@ -118,7 +115,14 @@ pub fn find_deployed_estimator_by_model_id(model_id: i64) -> Arc<Box<dyn Binding
                 _ => todo!(), //smartcore_load(&data, task, algorithm, &hyperparams),
             }
         }
+
+        #[cfg(feature = "sklearn")]
         Runtime::python => crate::bindings::sklearn::Estimator::from_bytes(&data),
+
+        #[cfg(not(feature = "sklearn"))]
+        Runtime::python => {
+            error!("Python runtime not supported, recompile with `--features sklearn`")
+        }
     };
 
     // Cache the estimator in process memory.

--- a/pgml-extension/src/orm/file.rs
+++ b/pgml-extension/src/orm/file.rs
@@ -116,10 +116,10 @@ pub fn find_deployed_estimator_by_model_id(model_id: i64) -> Arc<Box<dyn Binding
             }
         }
 
-        #[cfg(feature = "sklearn")]
+        #[cfg(feature = "python")]
         Runtime::python => crate::bindings::sklearn::Estimator::from_bytes(&data),
 
-        #[cfg(not(feature = "sklearn"))]
+        #[cfg(not(feature = "python"))]
         Runtime::python => {
             error!("Python runtime not supported, recompile with `--features sklearn`")
         }

--- a/pgml-extension/src/orm/model.rs
+++ b/pgml-extension/src/orm/model.rs
@@ -157,7 +157,7 @@ impl Model {
 
             #[cfg(not(feature = "python"))]
             Runtime::python => {
-                error!("Python runtime not supported, recompile with `--features scikit`")
+                error!("Python runtime not supported, recompile with `--features python`")
             }
 
             #[cfg(feature = "python")]

--- a/pgml-extension/src/orm/model.rs
+++ b/pgml-extension/src/orm/model.rs
@@ -154,6 +154,13 @@ impl Model {
                     _ => todo!(),
                 },
             },
+
+            #[cfg(not(feature = "sklearn"))]
+            Runtime::python => {
+                error!("Python runtime not supported, recompile with `--features scikit`")
+            }
+
+            #[cfg(feature = "sklearn")]
             Runtime::python => match project.task {
                 Task::regression => match self.algorithm {
                     Algorithm::linear => sklearn::linear_regression,

--- a/pgml-extension/src/orm/model.rs
+++ b/pgml-extension/src/orm/model.rs
@@ -155,12 +155,12 @@ impl Model {
                 },
             },
 
-            #[cfg(not(feature = "sklearn"))]
+            #[cfg(not(feature = "python"))]
             Runtime::python => {
                 error!("Python runtime not supported, recompile with `--features scikit`")
             }
 
-            #[cfg(feature = "sklearn")]
+            #[cfg(feature = "python")]
             Runtime::python => match project.task {
                 Task::regression => match self.algorithm {
                     Algorithm::linear => sklearn::linear_regression,


### PR DESCRIPTION
Some older systems may not have the Python version we want (Python 3.7+). We should not deprive them of the ability to run this extension, they will still benefit from XGBoost, LightGBM and Linfa.