### PR TITLE
Hot fixing 2.0

### DIFF
--- a/pgml-extension/sql/schema.sql
+++ b/pgml-extension/sql/schema.sql
@@ -2,6 +2,7 @@
 --- Validate we have the necessary Python dependencies.
 ---
 SELECT pgml.validate_python_dependencies();
+SELECT pgml.validate_shared_library();
 
 --- 
 --- Track of updates to data

--- a/pgml-extension/src/api.rs
+++ b/pgml-extension/src/api.rs
@@ -60,6 +60,21 @@ pub fn validate_python_dependencies() {
 #[pg_extern]
 pub fn validate_python_dependencies() {}
 
+#[pg_extern]
+pub fn validate_shared_library() {
+    let shared_preload_libraries: String = Spi::get_one(
+        "SELECT setting
+         FROM pg_settings
+         WHERE name = 'shared_preload_libraries'
+         LIMIT 1",
+    )
+    .unwrap();
+
+    if !shared_preload_libraries.contains("pgml") {
+        error!("`pgml` must be added to `shared_preload_libraries` setting or models cannot be deployed");
+    }
+}
+
 #[cfg(feature = "python")]
 #[pg_extern]
 pub fn sklearn_version() -> String {
@@ -102,6 +117,7 @@ pub fn python_version() -> String {
 fn version() -> String {
     crate::VERSION.to_string()
 }
+
 #[allow(clippy::too_many_arguments)]
 #[pg_extern]
 fn train(

--- a/pgml-extension/src/orm/dataset.rs
+++ b/pgml-extension/src/orm/dataset.rs
@@ -22,8 +22,8 @@ impl Display for Dataset {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(
             f,
-            "Dataset {{ num_features: {}, num_labels: {}, num_rows: {}, num_train_rows: {}, num_test_rows: {} }}",
-            self.num_features, self.num_labels, self.num_rows, self.num_train_rows, self.num_test_rows,
+            "Dataset {{ num_features: {}, num_labels: {}, num_distinct_labels: {}, num_rows: {}, num_train_rows: {}, num_test_rows: {} }}",
+            self.num_features, self.num_labels, self.num_distinct_labels, self.num_rows, self.num_train_rows, self.num_test_rows,
         )
     }
 }

--- a/pgml-extension/src/orm/snapshot.rs
+++ b/pgml-extension/src/orm/snapshot.rs
@@ -196,6 +196,11 @@ impl Snapshot {
                 let nullable = row[3].value::<bool>().unwrap();
                 let position = row[4].value::<i32>().unwrap() as usize;
                 let label = self.y_column_name.contains(&name);
+
+                if nullable {
+                    warning!("Column \"{}\" can contain nulls which can cause errors", name);
+                }
+
                 columns.push(
                     Column {
                         name,


### PR DESCRIPTION
1. Fix XGBoost regression thinking it's classifying.
2. Warn if columns contain nulls because if they do, the parsing step in Rust will fail.
3. Check on extension creation that it's loaded in shared memory.