### PR TITLE
Fully qualify table name

### DIFF
--- a/pgml-dashboard/pgml_dashboard/settings.py
+++ b/pgml-dashboard/pgml_dashboard/settings.py
@@ -108,7 +108,7 @@ database = urlparse(os.environ.get("PGML_DATABASE_URL", "postgres:///pgml_develo
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
-        "OPTIONS": {"options": "-c search_path=pgml,public"},
+        "OPTIONS": {"options": "-c search_path=public,pgml"},
         "NAME": database.path[1:],
         "USER": database.username,
         "PASSWORD": database.password,

--- a/pgml-extension/Cargo.lock
+++ b/pgml-extension/Cargo.lock
@@ -1630,7 +1630,7 @@ dependencies = [
 
 [[package]]
 name = "pgml"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "blas",

--- a/pgml-extension/Cargo.toml
+++ b/pgml-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgml"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 
 [lib]

--- a/pgml-extension/docker/entrypoint.sh
+++ b/pgml-extension/docker/entrypoint.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 # Exit on error, real CI
-set -e
-
 echo "Starting Postgres..."
 service postgresql start
 

--- a/pgml-extension/src/api.rs
+++ b/pgml-extension/src/api.rs
@@ -538,6 +538,7 @@ mod tests {
     #[pg_test]
     fn test_snapshot_lifecycle() {
         load_diabetes(Some(25));
+
         let snapshot = Snapshot::create(
             "pgml.diabetes",
             vec!["target".to_string()],
@@ -545,6 +546,19 @@ mod tests {
             Sampling::last,
         );
         assert!(snapshot.id > 0);
+    }
+
+    #[pg_test]
+    #[should_panic]
+    fn test_not_fully_qualified_table() {
+        load_diabetes(Some(25));
+
+        let result = std::panic::catch_unwind(|| {
+            let _snapshot =
+                Snapshot::create("diabetes", vec!["target".to_string()], 0.5, Sampling::last);
+        });
+
+        assert!(result.is_err());
     }
 
     #[pg_test]


### PR DESCRIPTION
1. Create tables in the public schema in the dashboard by default
2. Check that the table exists in the public schema or otherwise request fully qualified table name