### PR TITLE
Postgres wont cast double to float

### DIFF
--- a/pgml-dashboard/app/fixtures/notebook_cells.yml
+++ b/pgml-dashboard/app/fixtures/notebook_cells.yml
@@ -934,7 +934,7 @@
     notebook: 1
     cell_type: 3
     contents: "SELECT \n  perishable_percentage, \n  fraudulent, \n  pgml.predict('Our
-      Fraud Classification', ARRAY[perishable_percentage]) AS predict_fraud \nFROM
+      Fraud Classification', ARRAY[perishable_percentage::real]) AS predict_fraud \nFROM
       fraud_samples;"
     rendering: null
     execution_time: null
@@ -965,7 +965,7 @@
     cell_type: 3
     contents: "WITH exploration_samples AS (\n  SELECT generate_series(0, 1, 0.1)
       AS perishable_percentage\n)\nSELECT \n  perishable_percentage, \n  pgml.predict('Our
-      Fraud Classification', ARRAY[perishable_percentage]) AS predict_fraud \nFROM
+      Fraud Classification', ARRAY[perishable_percentage::real]) AS predict_fraud \nFROM
       exploration_samples;"
     rendering: null
     execution_time: null
@@ -1091,8 +1091,8 @@
     notebook: 1
     cell_type: 3
     contents: "SELECT \n  perishable_amount, \n  non_perishable_amount, \n  fraudulent,
-      \n  pgml.predict(\n    'Our Fraud Classification', \n    ARRAY[perishable_amount,
-      non_perishable_amount]\n  ) AS predict_fraud \nFROM fraud_samples;"
+      \n  pgml.predict(\n    'Our Fraud Classification', \n    ARRAY[perishable_amount::real,
+      non_perishable_amount::real]\n  ) AS predict_fraud \nFROM fraud_samples;"
     rendering: null
     execution_time: null
     cell_number: 52


### PR DESCRIPTION
I think because of loss of precision, it won't automatically cast a double to a float during function calls.