### PR TITLE
Fix OID that should of been broken a while ago but wasn't

### DIFF
--- a/pgml-extension/src/orm/model.rs
+++ b/pgml-extension/src/orm/model.rs
@@ -105,7 +105,7 @@ impl Model {
                   (PgBuiltInOids::TEXTOID.oid(), search.map(|search| search.to_string()).into_datum()),
                   (PgBuiltInOids::JSONBOID.oid(), search_params.into_datum()),
                   (PgBuiltInOids::JSONBOID.oid(), search_args.into_datum()),
-                  (PgBuiltInOids::INT4OID.oid(), (dataset.num_features as i64).into_datum()),
+                  (PgBuiltInOids::INT8OID.oid(), (dataset.num_features as i64).into_datum()),
               ])
           ).first();
             if !result.is_empty() {


### PR DESCRIPTION
What was `usize` being cast to before? Mystery.