### PR TITLE
pgml.predict with a record

### DIFF
--- a/pgml-extension/Cargo.lock
+++ b/pgml-extension/Cargo.lock
@@ -1571,6 +1571,7 @@ dependencies = [
  "openblas-src",
  "parking_lot",
  "pgx",
+ "pgx-pg-sys",
  "pgx-tests",
  "pyo3",
  "rand",

--- a/pgml-extension/Cargo.toml
+++ b/pgml-extension/Cargo.toml
@@ -18,6 +18,7 @@ cuda = ["xgboost/cuda", "lightgbm/cuda"]
 
 [dependencies]
 pgx = "=0.5.6"
+pgx-pg-sys = "=0.5.6"
 xgboost = { git="https://github.com/postgresml/rust-xgboost.git", branch = "master" }
 once_cell = "1"
 rand = "0.8"


### PR DESCRIPTION
Create a version of `pgml.predict()` that accepts a `ROW`, aka anonymous composite type. Composite types are unsafe because the caller cannot verify, yet, that the function truly received a `row` argument. The `record` type should be exposed in pgx to make this happen.

Otherwise, they are pretty straight forward to work with.

Test with:

```
select pgml.predict('test', (1, 2, 'hello'::text));
```