### PR TITLE
Batch predictions

### DIFF
--- a/pgml-docs/mkdocs.yml
+++ b/pgml-docs/mkdocs.yml
@@ -129,6 +129,7 @@ nav:
             - Joint Optimization: user_guides/training/joint_optimization.md
         - Predictions: 
             - Prediction Overview: user_guides/predictions/overview.md
+            - Batch Predictions: user_guides/predictions/batch.md
             - Deploying Models: user_guides/predictions/deployments.md
         - Vector Operations: user_guides/vector_operations/overview.md
         - Transformers:

--- a/pgml-extension/src/api.rs
+++ b/pgml-extension/src/api.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fmt::Write;
 use std::str::FromStr;
 
-use pgx::iter::{TableIterator, SetOfIterator};
+use pgx::iter::{SetOfIterator, TableIterator};
 use pgx::*;
 
 #[cfg(feature = "python")]
@@ -402,7 +402,7 @@ fn predict_joint(project_name: &str, features: Vec<f32>) -> Vec<f32> {
 #[pg_extern(strict, name = "predict_batch")]
 fn predict_batch(project_name: &str, features: Vec<f32>) -> SetOfIterator<'static, f32> {
     SetOfIterator::new(
-        predict_model_batch(Project::get_deployed_model_id(project_name), features).into_iter()
+        predict_model_batch(Project::get_deployed_model_id(project_name), features).into_iter(),
     )
 }
 

--- a/pgml-extension/src/api.rs
+++ b/pgml-extension/src/api.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fmt::Write;
 use std::str::FromStr;
 
-use pgx::iter::TableIterator;
+use pgx::iter::{TableIterator, SetOfIterator};
 use pgx::*;
 
 #[cfg(feature = "python")]
@@ -400,8 +400,10 @@ fn predict_joint(project_name: &str, features: Vec<f32>) -> Vec<f32> {
 }
 
 #[pg_extern(strict, name = "predict_batch")]
-fn predict_batch(project_name: &str, features: Vec<f32>) -> Vec<f32> {
-    predict_model_batch(Project::get_deployed_model_id(project_name), features)
+fn predict_batch(project_name: &str, features: Vec<f32>) -> SetOfIterator<'static, f32> {
+    SetOfIterator::new(
+        predict_model_batch(Project::get_deployed_model_id(project_name), features).into_iter()
+    )
 }
 
 #[pg_extern(strict, name = "predict")]


### PR DESCRIPTION
Add documentation and modify `pgml.batch_predict` to return `setof` to avoid an unnecessary `unnest`.