### PR TITLE
Adds pipeline model caching in the `transform` function.

### DIFF
--- a/pgml-docs/docs/user_guides/transformers/pre_trained_models.md
+++ b/pgml-docs/docs/user_guides/transformers/pre_trained_models.md
@@ -11,9 +11,10 @@ The Hugging Face [`Pipeline`](https://huggingface.co/docs/transformers/main_clas
 
 ```sql linenums="1" title="transformer.sql"
 pgml.transform(
-    task TEXT OR JSONB,      -- task name or full pipeline initializer arguments
-    call JSONB,              -- additional call arguments alongside the inputs
-    inputs TEXT[] OR BYTEA[] -- inputs for inference
+    task TEXT OR JSONB,       -- task name or full pipeline initializer arguments
+    call JSONB,               -- additional call arguments alongside the inputs
+    inputs TEXT[] OR BYTEA[], -- inputs for inference
+    cache_model BOOLEAN       -- if true, the model will be cached in memory. FALSE by default
 )
 ```
 
@@ -73,7 +74,8 @@ Sentiment analysis is one use of `text-classification`, but there are [many othe
         inputs => ARRAY[
             'I love how amazingly simple ML has become!', 
             'I hate doing mundane and thankless tasks. ☹️'
-        ]
+        ],
+        cache_model => TRUE
     ) AS positivity;
     ```
 

--- a/pgml-docs/docs/user_guides/transformers/pre_trained_models.md
+++ b/pgml-docs/docs/user_guides/transformers/pre_trained_models.md
@@ -14,7 +14,7 @@ pgml.transform(
     task TEXT OR JSONB,       -- task name or full pipeline initializer arguments
     call JSONB,               -- additional call arguments alongside the inputs
     inputs TEXT[] OR BYTEA[], -- inputs for inference
-    cache_model BOOLEAN       -- if true, the model will be cached in memory. FALSE by default
+    cache BOOLEAN             -- if TRUE, the model will be cached in memory. FALSE by default.
 )
 ```
 
@@ -75,7 +75,7 @@ Sentiment analysis is one use of `text-classification`, but there are [many othe
             'I love how amazingly simple ML has become!', 
             'I hate doing mundane and thankless tasks. ☹️'
         ],
-        cache_model => TRUE
+        cache => TRUE
     ) AS positivity;
     ```
 

--- a/pgml-extension/Cargo.lock
+++ b/pgml-extension/Cargo.lock
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "pgml"
-version = "2.5.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "blas",

--- a/pgml-extension/Cargo.lock
+++ b/pgml-extension/Cargo.lock
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "pgml"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "blas",

--- a/pgml-extension/src/api.rs
+++ b/pgml-extension/src/api.rs
@@ -564,10 +564,10 @@ pub fn transform_json(
     task: JsonB,
     args: default!(JsonB, "'{}'"),
     inputs: default!(Vec<String>, "ARRAY[]::TEXT[]"),
-    cache_model: default!(bool, false)
+    cache: default!(bool, false)
 ) -> JsonB {
     JsonB(crate::bindings::transformers::transform(
-        &task.0, &args.0, &inputs, cache_model
+        &task.0, &args.0, &inputs, cache
     ))
 }
 
@@ -577,13 +577,13 @@ pub fn transform_string(
     task: String,
     args: default!(JsonB, "'{}'"),
     inputs: default!(Vec<String>, "ARRAY[]::TEXT[]"),
-    cache_model: default!(bool, false)
+    cache: default!(bool, false)
 ) -> JsonB {
     let mut task_map = HashMap::new();
     task_map.insert("task", task);
     let task_json = json!(task_map);
     JsonB(crate::bindings::transformers::transform(
-        &task_json, &args.0, &inputs, cache_model
+        &task_json, &args.0, &inputs, cache
     ))
 }
 

--- a/pgml-extension/src/api.rs
+++ b/pgml-extension/src/api.rs
@@ -564,9 +564,10 @@ pub fn transform_json(
     task: JsonB,
     args: default!(JsonB, "'{}'"),
     inputs: default!(Vec<String>, "ARRAY[]::TEXT[]"),
+    cache_model: default!(bool, false)
 ) -> JsonB {
     JsonB(crate::bindings::transformers::transform(
-        &task.0, &args.0, &inputs,
+        &task.0, &args.0, &inputs, cache_model
     ))
 }
 
@@ -576,12 +577,13 @@ pub fn transform_string(
     task: String,
     args: default!(JsonB, "'{}'"),
     inputs: default!(Vec<String>, "ARRAY[]::TEXT[]"),
+    cache_model: default!(bool, false)
 ) -> JsonB {
     let mut task_map = HashMap::new();
     task_map.insert("task", task);
     let task_json = json!(task_map);
     JsonB(crate::bindings::transformers::transform(
-        &task_json, &args.0, &inputs,
+        &task_json, &args.0, &inputs, cache_model
     ))
 }
 

--- a/pgml-extension/src/bindings/transformers.py
+++ b/pgml-extension/src/bindings/transformers.py
@@ -39,6 +39,7 @@ from transformers import (
 
 __cache_transformer_by_model_id = {}
 __cache_sentence_transformer_by_name = {}
+__cache_transform_pipeline_model_by_name = {}
 
 class NumpyJSONEncoder(json.JSONEncoder):
     def default(self, obj):
@@ -46,12 +47,18 @@ class NumpyJSONEncoder(json.JSONEncoder):
             return float(obj)
         return super().default(obj)
 
-def transform(task, args, inputs):
+def transform(task, args, inputs, cache_model):
     task = json.loads(task)
     args = json.loads(args)
     inputs = json.loads(inputs)
 
-    pipe = transformers.pipeline(**task)
+    model = task.get("model")
+    cached_model = __cache_transform_pipeline_model_by_name.get(model) if model is not None else None
+    
+    pipe = cached_model or transformers.pipeline(**task)
+
+    if cache_model and cached_model is None and model is not None:
+        __cache_transform_pipeline_model_by_name[model] = pipe
 
     if pipe.task == "question-answering":
         inputs = [json.loads(input) for input in inputs]

--- a/pgml-extension/src/bindings/transformers.rs
+++ b/pgml-extension/src/bindings/transformers.rs
@@ -25,7 +25,7 @@ pub fn transform(
     task: &serde_json::Value,
     args: &serde_json::Value,
     inputs: &Vec<String>,
-    cache_model: bool 
+    cache: bool 
 ) -> serde_json::Value {
     let task = serde_json::to_string(task).unwrap();
     let args = serde_json::to_string(args).unwrap();
@@ -39,7 +39,7 @@ pub fn transform(
                 py,
                 PyTuple::new(
                     py,
-                    &[task.into_py(py), args.into_py(py), inputs.into_py(py), cache_model.into_py(py)],
+                    &[task.into_py(py), args.into_py(py), inputs.into_py(py), cache.into_py(py)],
                 ),
             )
             .unwrap()

--- a/pgml-extension/src/bindings/transformers.rs
+++ b/pgml-extension/src/bindings/transformers.rs
@@ -25,6 +25,7 @@ pub fn transform(
     task: &serde_json::Value,
     args: &serde_json::Value,
     inputs: &Vec<String>,
+    cache_model: bool 
 ) -> serde_json::Value {
     let task = serde_json::to_string(task).unwrap();
     let args = serde_json::to_string(args).unwrap();
@@ -38,7 +39,7 @@ pub fn transform(
                 py,
                 PyTuple::new(
                     py,
-                    &[task.into_py(py), args.into_py(py), inputs.into_py(py)],
+                    &[task.into_py(py), args.into_py(py), inputs.into_py(py), cache_model.into_py(py)],
                 ),
             )
             .unwrap()


### PR DESCRIPTION
This PR adds the ability to run a query that looks like this:

```
SELECT pgml.transform(
        '{"model": "roberta-large-mnli"}'::JSONB, 
        inputs => ARRAY[
            'I love how amazingly simple ML has become!', 
            'I hate doing mundane and thankless tasks. ☹️'
        ],
        cache => TRUE
    ) AS positivity;
```

`roberta-large-mnli` will be cached in memory to prevent `transformers.pipeline()` from being called more than once for the same model.

By default, `cache` is `FALSE`.