### PR TITLE
Adding filtering based on metadata using kwargs

### DIFF
--- a/pgml-sdks/python/pgml/examples/question_answering.py
+++ b/pgml-sdks/python/pgml/examples/question_answering.py
@@ -33,7 +33,7 @@ collection.generate_embeddings()
 
 start = time()
 query = "Who won 20 grammy awards?"
-results = collection.vector_search(query, top_k=5)
+results = collection.vector_search(query, top_k=5, title="Beyoncé")
 _end = time()
 console.print("\nResults for '%s'" % (query), style="bold")
 console.print(results)


### PR DESCRIPTION
Improving the vector search by adding filtering based on the additional kwargs. Adding from [#663](https://github.com/postgresml/postgresml/issues/663). 

You can add additional metadata filters by passing them in the `vector_search` call. For example, if you want to filter by title:

`results = collection.vector_search(query, top_k=5, title='Beyonce')` or by page_number
`results = collection.vector_search(query, top_k=5, page_number=13)`