### PR TITLE
Updating requirements.txt to fix warning of xformers

### DIFF
--- a/pgml-extension/requirements.txt
+++ b/pgml-extension/requirements.txt
@@ -17,6 +17,7 @@ torchaudio==2.0.2
 torchvision==0.15.2
 tqdm==4.65.0
 transformers==4.29.2
+xformers==0.0.20
 xgboost==1.7.5
 langchain==0.0.180
 einops==0.6.1


### PR DESCRIPTION
Adding Xformers to get rid of `Xformers is not installed correctly. If you want to use memorry_efficient_attention to accelerate training use the following command to install Xformers`. 