### PR TITLE
remove links from open source footer

### DIFF
--- a/pgml-dashboard/src/utils/config.rs
+++ b/pgml-dashboard/src/utils/config.rs
@@ -32,13 +32,6 @@ pub fn static_dir() -> String {
     }
 }
 
-// pub fn content_dir() -> String {
-//     match var("CONTENT_DIRECTORY") {
-//         Ok(dir) => dir,
-//         Err(_) => "content".to_string(),
-//     }
-// }
-
 pub fn search_index_dir() -> String {
     match var("SEARCH_INDEX_DIRECTORY") {
         Ok(path) => path,

--- a/pgml-dashboard/templates/layout/footer.html
+++ b/pgml-dashboard/templates/layout/footer.html
@@ -15,6 +15,7 @@
           <a class="nav-link text-white" href="https://discord.gg/DmyJP3qJ7U">Discord</a>
         </nav>
       </div>
+      <% if !crate::utils::config::standalone_dashboard() {; %>
       <div class="col-12 col-lg-6 col-xl-4">
         <nav class="nav d-flex flex-column">
           <a class="nav-link text-white" href="<%= crate::utils::config::signup_url() %>">Create an Account</a>
@@ -23,6 +24,7 @@
           <a class="nav-link text-white" href="/privacy" data-turbo="false">Privacy Policy</a>
         </nav>
       </div>
+      <% } %>
     </div>
   </div>
 


### PR DESCRIPTION
Remove login, signup, tos, privacy policy links from footer when in dashboard/docs in stand_alone mode. 
Remove commented out code. 