### PR TITLE
Docker fix of the day

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
     environment:
       ROCKET_ADDRESS: 0.0.0.0
       DATABASE_URL: postgres://postgres:postgres@postgres:5432/pgml_development
+      RUST_LOG: info
     command: bash -c "sqlx migrate run && cargo run"
 
 volumes:

--- a/pgml-dashboard/.dockerignore
+++ b/pgml-dashboard/.dockerignore
@@ -1,1 +1,2 @@
 target/
+search_index/

--- a/pgml-dashboard/Dockerfile
+++ b/pgml-dashboard/Dockerfile
@@ -1,4 +1,6 @@
 FROM rust:1
+RUN cargo install sqlx-cli
+RUN apt-get update && apt-get install -y nodejs npm
+RUN npm install -g sass
 COPY . /app
 WORKDIR /app
-RUN cargo install sqlx-cli

--- a/pgml-dashboard/build.rs
+++ b/pgml-dashboard/build.rs
@@ -18,10 +18,10 @@ fn main() {
         .arg("static/css/bootstrap-theme.scss")
         .arg("static/css/style.css")
         .status()
-        .unwrap();
+        .expect("`npm exec sass` failed");
 
     if !status.success() {
-        println!("SCSS compilation failed");
+        println!("SCSS compilation failed to run");
     }
 
     // Bundle CSS to bust cache.
@@ -38,7 +38,7 @@ fn main() {
         .arg("static/css/style.css")
         .arg(format!("static/css/style.{}.css", css_version))
         .status()
-        .unwrap()
+        .expect("cp static/css/style.css failed to run")
         .success()
     {
         println!("Bundling CSS failed");
@@ -54,7 +54,7 @@ fn main() {
     // Build JS to bust cache
     for file in glob::glob("static/js/*.js").expect("failed to glob") {
         let file = file.expect("failed to glob path");
-        let contents = read_to_string(file).unwrap().as_bytes().to_vec();
+        let contents = read_to_string(file).expect("failed to read js file").as_bytes().to_vec();
 
         js_version.push(format!("{:x}", md5::compute(contents)));
     }
@@ -73,7 +73,7 @@ fn main() {
             .arg(&filename)
             .arg(format!("{}.{}.js", name, js_version))
             .status()
-            .unwrap()
+            .expect("failed to cp js file")
             .success()
         {
             println!("Bundling JS failed");

--- a/pgml-dashboard/templates/layout/footer.html
+++ b/pgml-dashboard/templates/layout/footer.html
@@ -15,7 +15,7 @@
           <a class="nav-link text-white" href="https://discord.gg/DmyJP3qJ7U">Discord</a>
         </nav>
       </div>
-      <% if !crate::utils::config::standalone_dashboard() {; %>
+      <% if !crate::utils::config::standalone_dashboard() { %>
       <div class="col-12 col-lg-6 col-xl-4">
         <nav class="nav d-flex flex-column">
           <a class="nav-link text-white" href="<%= crate::utils::config::signup_url() %>">Create an Account</a>

--- a/pgml-dashboard/templates/layout/nav/top.html
+++ b/pgml-dashboard/templates/layout/nav/top.html
@@ -51,6 +51,6 @@
       </div>
     </div>
   </div>
-  <% include!("../../components/search_modal.html");%>
+  <% include!("../../components/search_modal.html"); %>
 </nav>
 

--- a/pgml-extension/.dockerignore
+++ b/pgml-extension/.dockerignore
@@ -1,6 +1,7 @@
 # Cargo
 Cargo.lock
-/target
+target/
+venv/
 **/*.rs.bk
 
 # PyCharm

--- a/pgml-extension/Dockerfile
+++ b/pgml-extension/Dockerfile
@@ -1,31 +1,48 @@
 FROM nvidia/cuda:12.1.1-devel-ubuntu22.04
 LABEL maintainer="team@postgresml.com"
 
-RUN apt-get update
 ARG DEBIAN_FRONTEND=noninteractive
+ARG PGML_VERSION=2.5.2
 ENV TZ=Etc/UTC
 ENV PATH="/usr/local/cuda/bin:${PATH}"
 
-RUN apt-get update && apt-get install -y curl lsb-release python3 python3-pip tzdata sudo cmake libpq-dev libclang-dev wget git
-
+# Dependencies
 RUN apt-get update && \
-    apt-get install -y wget gnupg lsb-release && \
-    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+    apt-get install -y \
+    curl \
+    lsb-release \
+    python3 \
+    python3-pip \
+    tzdata \
+    sudo \
+    cmake \
+    libpq-dev \
+    libclang-dev \
+    wget \
+    git \
+    gnupg \
+    lsb-release
+
+# PostgreSQL
+RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
     echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
     apt-get update && \
     apt-get install -y postgresql-14 && \
     apt-get install -y postgresql-plpython3-14
 
-
+# PostgresML
 RUN echo "deb [trusted=yes] https://apt.postgresml.org $(lsb_release -cs) main" >> /etc/apt/sources.list
 RUN cat /etc/apt/sources.list
-RUN apt-get update && apt-get install -y postgresql-pgml-14
-# Cache this, quicker
-COPY --chown=postgres:postgres . /app
+RUN apt-get update && apt-get install -y postgresql-pgml-14=${PGML_VERSION}
+
+COPY --chown=postgres:postgres requirements.txt /app/requirements.txt
 WORKDIR /app
 RUN pip3 install -r requirements.txt
+
+COPY --chown=postgres:postgres requirements-xformers.txt /app/requirements-xformers.txt
 RUN pip3 install -r requirements-xformers.txt --no-dependencies
 
+COPY --chown=postgres:postgres . /app
 # Listen on 0.0.0.0 and allow 'root' to connect without a password.
 # Please modify for production deployments accordingly.
 RUN cp /app/docker/postgresql.conf /etc/postgresql/14/main/postgresql.conf
@@ -36,5 +53,4 @@ RUN cd /tmp && \
     make && \
     make install
 
-WORKDIR /app
 ENTRYPOINT ["/bin/bash", "/app/docker/entrypoint.sh"]

--- a/pgml-extension/docker/entrypoint.sh
+++ b/pgml-extension/docker/entrypoint.sh
@@ -25,7 +25,7 @@ done
 fi
 
 echo "Installing pgvector.. "
-psql -U postgres -h 127.0.0.1 pgml_development -c 'CREATE EXTENSION vector'
+psql -U postgres -h 127.0.0.1 pgml_development -c 'CREATE EXTENSION IF NOT EXISTS vector'
 
 echo "Ready!"
 if [[ ! -z $@ ]]; then

--- a/pgml-extension/examples/binary_classification.sql
+++ b/pgml-extension/examples/binary_classification.sql
@@ -1,5 +1,5 @@
 -- Exit on error (psql)
-\set ON_ERROR_STOP true
+-- \set ON_ERROR_STOP true
 \timing on
 
 SELECT pgml.load_dataset('breast_cancer');

--- a/pgml-extension/examples/finetune.sql
+++ b/pgml-extension/examples/finetune.sql
@@ -1,5 +1,5 @@
 -- Exit on error (psql)
-\set ON_ERROR_STOP true
+-- \set ON_ERROR_STOP true
 \timing on
 
 

--- a/pgml-extension/examples/image_classification.sql
+++ b/pgml-extension/examples/image_classification.sql
@@ -10,7 +10,7 @@
 -- solutions can solve problems these days.
 
 -- Exit on error (psql)
-\set ON_ERROR_STOP true
+-- \set ON_ERROR_STOP true
 \timing on
 
 SELECT pgml.load_dataset('digits');

--- a/pgml-extension/examples/joint_regression.sql
+++ b/pgml-extension/examples/joint_regression.sql
@@ -3,7 +3,7 @@
 -- for regression, along with multiple jointly optimized targets.
 
 -- Exit on error (psql)
-\set ON_ERROR_STOP true
+-- \set ON_ERROR_STOP true
 \timing on
 
 SELECT pgml.load_dataset('linnerud');

--- a/pgml-extension/examples/multi_classification.sql
+++ b/pgml-extension/examples/multi_classification.sql
@@ -1,5 +1,5 @@
 -- Exit on error (psql)
-\set ON_ERROR_STOP true
+-- \set ON_ERROR_STOP true
 \timing on
 
 SELECT pgml.load_dataset('iris');

--- a/pgml-extension/examples/regression.sql
+++ b/pgml-extension/examples/regression.sql
@@ -10,7 +10,7 @@
 -- for regression.
 
 -- Exit on error (psql)
-\set ON_ERROR_STOP true
+-- \set ON_ERROR_STOP true
 \timing on
 
 SELECT pgml.load_dataset('diabetes');

--- a/pgml-extension/examples/transformers.sql
+++ b/pgml-extension/examples/transformers.sql
@@ -1,5 +1,5 @@
 -- Exit on error (psql)
-\set ON_ERROR_STOP true
+-- \set ON_ERROR_STOP true
 \timing on
 
 SELECT pgml.embed('intfloat/e5-small', 'hi mom');

--- a/pgml-extension/examples/vectors.sql
+++ b/pgml-extension/examples/vectors.sql
@@ -1,5 +1,5 @@
 -- Exit on error (psql)
-\set ON_ERROR_STOP true
+-- \set ON_ERROR_STOP true
 \timing on
 
 -- Elementwise arithmetic w/ constants

--- a/pgml-extension/sql/setup_examples.sql
+++ b/pgml-extension/sql/setup_examples.sql
@@ -6,13 +6,13 @@
 ---   $ cargo pgrx run --release
 ---   $ psql -P pager-off -h localhost -p 28813 -d pgml -f sql/setup_examples.sql
 ---
-\set ON_ERROR_STOP true
+-- \set ON_ERROR_STOP true
 \timing on
 
 -- The intention is to only allow setup_examples.sql to run on a database that
 -- has not had example data installed before, e.g. docker run. This should
 -- error and stop the process if the extension is already present.
-CREATE EXTENSION pgml;
+CREATE EXTENSION IF NOT EXISTS pgml;
 
 SELECT pgml.load_dataset('breast_cancer');
 SELECT pgml.load_dataset('diabetes');


### PR DESCRIPTION
### Bugs

- Fix dashboard not starting up because of missing dependencies: npm, nodejs, sass.
- Bust Docker cache on `pgml-exension` build when PostgresML version changes
- Remove compilation warning for `pgml-dashboard` (extra semicolumn).
- Don't fail `setup_examples.sql` if things already exist. We have a volume now, they will fail every time the container starts up otherwise.

### Features

- Move around things in `pgml-extension/Dockerfile` to benefit more from Docker's layers and build things faster.