### PR TITLE
Upgrade to pgrx 0.9.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           curl https://sh.rustup.rs -sSf | sh -s -- -y
           source ~/.cargo/env
-          cargo install cargo-pgrx --version "0.9.2" --locked
+          cargo install cargo-pgrx --version "0.9.7" --locked
 
           if [[ ! -d ~/.pgrx ]]; then
             cargo pgrx init

--- a/.github/workflows/package-extension.yml
+++ b/.github/workflows/package-extension.yml
@@ -84,7 +84,7 @@ jobs:
       with:
         working-directory: pgml-extension
         command: install
-        args: cargo-pgrx --version "0.9.2" --locked
+        args: cargo-pgrx --version "0.9.7" --locked
     - name: pgrx init
       uses: postgresml/gh-actions-cargo@master
       with:

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -74,7 +74,7 @@ ENV PATH="/home/postgresml/.cargo/bin:${PATH}"
 
 
 # Install pgrx
-RUN cargo install cargo-pgrx --version "0.9.2" --locked
+RUN cargo install cargo-pgrx --version "0.9.7" --locked
 
 
 COPY --chown=postgresml:postgresml ./ /app

--- a/pgml-dashboard/content/docs/guides/setup/developers.md
+++ b/pgml-dashboard/content/docs/guides/setup/developers.md
@@ -70,7 +70,7 @@ Once there, you can initialize `pgrx` and get going:
 
 #### Pgrx command line and environments
 ```commandline
-cargo install cargo-pgrx --version "0.9.2" --locked && \
+cargo install cargo-pgrx --version "0.9.7" --locked && \
 cargo pgrx init # This will take a few minutes
 ```
 

--- a/pgml-dashboard/content/docs/guides/setup/v2/installation.md
+++ b/pgml-dashboard/content/docs/guides/setup/v2/installation.md
@@ -97,7 +97,7 @@ version accordingly if yours is different. Other flavors of Linux should work, b
 
     ```
     export POSTGRES_VERSION=15
-    cargo install cargo-pgrx --version "0.9.2" --locked && \
+    cargo install cargo-pgrx --version "0.9.7" --locked && \
     cargo pgrx init --pg${POSTGRES_VERSION} /usr/bin/pg_config && \
     cargo pgrx package
     ```
@@ -106,7 +106,7 @@ version accordingly if yours is different. Other flavors of Linux should work, b
     ```
     export POSTGRES_VERSION=15
     cp docker/Cargo.toml.no-python Cargo.toml && \
-    cargo install cargo-pgrx --version "0.9.2" --locked && \
+    cargo install cargo-pgrx --version "0.9.7" --locked && \
     cargo pgrx init --pg${POSTGRES_VERSION} /usr/bin/pg_config && \
     cargo pgrx package
     ```

--- a/pgml-extension/Cargo.toml
+++ b/pgml-extension/Cargo.toml
@@ -18,8 +18,8 @@ python = ["pyo3"]
 cuda = ["xgboost/cuda", "lightgbm/cuda"]
 
 [dependencies]
-pgrx = "=0.9.2"
-pgrx-pg-sys = "=0.9.2"
+pgrx = "=0.9.7"
+pgrx-pg-sys = "=0.9.7"
 xgboost = { git="https://github.com/postgresml/rust-xgboost.git", branch = "master" }
 once_cell = "1"
 rand = "0.8"
@@ -48,7 +48,7 @@ flate2 = "1.0"
 csv = "1.1"
 
 [dev-dependencies]
-pgrx-tests = "=0.9.2"
+pgrx-tests = "=0.9.7"
 
 [profile.dev]
 panic = "unwind"

--- a/pgml-extension/docker/Cargo.toml.cuda
+++ b/pgml-extension/docker/Cargo.toml.cuda
@@ -19,8 +19,8 @@ python = ["pyo3"]
 cuda = ["xgboost/cuda", "lightgbm/cuda"]
 
 [dependencies]
-pgrx = "=0.9.2"
-pgrx-pg-sys = "=0.9.2"
+pgrx = "=0.9.7"
+pgrx-pg-sys = "=0.9.7"
 xgboost = { git="https://github.com/postgresml/rust-xgboost.git", branch = "master" }
 once_cell = "1"
 rand = "0.8"
@@ -49,7 +49,7 @@ flate2 = "1.0"
 csv = "1.1"
 
 [dev-dependencies]
-pgrx-tests = "=0.9.2"
+pgrx-tests = "=0.9.7"
 
 [profile.dev]
 panic = "unwind"

--- a/pgml-extension/docker/Cargo.toml.no-python
+++ b/pgml-extension/docker/Cargo.toml.no-python
@@ -18,8 +18,8 @@ python = ["pyo3"]
 cuda = ["xgboost/cuda", "lightgbm/cuda"]
 
 [dependencies]
-pgrx = "=0.9.2"
-pgrx-pg-sys = "=0.9.2"
+pgrx = "=0.9.7"
+pgrx-pg-sys = "=0.9.7"
 xgboost = { git="https://github.com/postgresml/rust-xgboost.git", branch = "master" }
 once_cell = "1"
 rand = "0.8"
@@ -48,7 +48,7 @@ flate2 = "1.0"
 csv = "1.1"
 
 [dev-dependencies]
-pgrx-tests = "=0.9.2"
+pgrx-tests = "=0.9.7"
 
 [profile.dev]
 panic = "unwind"


### PR DESCRIPTION
A critical bug concerning handling arrays with an initial null element was discovered in pgrx versions 0.8.0 to 0.9.6, recommending an upgrade to 0.9.7 as soon as is possible. I was not able to run the necessary commands to update the lockfiles, my apologies.