### PR TITLE
pgml.python_pip_freeze()

### DIFF
--- a/pgml-extension/Cargo.lock
+++ b/pgml-extension/Cargo.lock
@@ -1807,7 +1807,7 @@ dependencies = [
 
 [[package]]
 name = "pgml"
-version = "2.7.1"
+version = "2.7.2"
 dependencies = [
  "anyhow",
  "blas",

--- a/pgml-extension/Cargo.toml
+++ b/pgml-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgml"
-version = "2.7.1"
+version = "2.7.2"
 edition = "2021"
 
 [lib]

--- a/pgml-extension/build.rs
+++ b/pgml-extension/build.rs
@@ -2,6 +2,6 @@ fn main() {
     #[cfg(target_os = "macos")]
     {
         println!("cargo:rustc-link-search=/opt/homebrew/opt/openblas/lib");
-        println!("cargo:rustc-link-search=/opt/homebrew/opt/libomp/lib/");
+        println!("cargo:rustc-link-search=/opt/homebrew/opt/libomp/lib");
     }
 }

--- a/pgml-extension/sql/pgml--2.7.1--2.7.2.sql
+++ b/pgml-extension/sql/pgml--2.7.1--2.7.2.sql
@@ -1,0 +1,8 @@
+-- src/api.rs:74
+-- pgml::api::python_pip_freeze
+CREATE FUNCTION pgml."python_pip_freeze"() RETURNS TABLE (
+    "package" TEXT  /* alloc::string::String */
+)
+STRICT
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'python_pip_freeze_wrapper';

--- a/pgml-extension/src/api.rs
+++ b/pgml-extension/src/api.rs
@@ -69,6 +69,16 @@ pub fn python_package_version(name: &str) {
     error!("Python is not installed, recompile with `--features python`");
 }
 
+#[cfg(feature = "python")]
+#[pg_extern]
+pub fn python_pip_freeze() -> TableIterator<'static, (name!(package, String),)> {
+    let packages = crate::bindings::venv::freeze()
+        .into_iter()
+        .map(|package| (package,));
+
+    TableIterator::new(packages)
+}
+
 #[pg_extern]
 pub fn validate_shared_library() {
     let shared_preload_libraries: String = Spi::get_one(

--- a/pgml-extension/src/api.rs
+++ b/pgml-extension/src/api.rs
@@ -72,6 +72,8 @@ pub fn python_package_version(name: &str) {
 #[cfg(feature = "python")]
 #[pg_extern]
 pub fn python_pip_freeze() -> TableIterator<'static, (name!(package, String),)> {
+    crate::bindings::venv::activate();
+
     let packages = crate::bindings::venv::freeze()
         .into_iter()
         .map(|package| (package,));

--- a/pgml-extension/src/bindings/venv.py
+++ b/pgml-extension/src/bindings/venv.py
@@ -26,13 +26,9 @@ def activate_venv(venv):
 
 
 def freeze():
-    packages = []
     try:
         from pip._internal.operations import freeze
     except ImportError: # pip < 10.0
         from pip.operations import freeze
 
-    pkgs = freeze.freeze()
-    for pkg in pkgs:
-        packages.append(pkg)
-    return packages
+    return list(freeze.freeze())

--- a/pgml-extension/src/bindings/venv.py
+++ b/pgml-extension/src/bindings/venv.py
@@ -25,7 +25,7 @@ def activate_venv(venv):
         return False
 
 
-def freeze(*args, **kwargs):
+def freeze():
     packages = []
     try:
         from pip._internal.operations import freeze

--- a/pgml-extension/src/bindings/venv.py
+++ b/pgml-extension/src/bindings/venv.py
@@ -23,3 +23,16 @@ def activate_venv(venv):
     else:
         print("Virtualenv not found: %s" % venv)
         return False
+
+
+def freeze(*args, **kwargs):
+    packages = []
+    try:
+        from pip._internal.operations import freeze
+    except ImportError: # pip < 10.0
+        from pip.operations import freeze
+
+    pkgs = freeze.freeze()
+    for pkg in pkgs:
+        packages.append(pkg)
+    return packages

--- a/pgml-extension/src/bindings/venv.rs
+++ b/pgml-extension/src/bindings/venv.rs
@@ -34,3 +34,12 @@ pub fn activate() -> bool {
         None => false,
     }
 }
+
+pub fn freeze() -> Vec<String> {
+    Python::with_gil(|py| -> Vec<String> {
+        let freeze: Py<PyAny> = PY_MODULE.getattr(py, "freeze").unwrap();
+        let result: Py<PyAny> = freeze.call0(py).unwrap();
+
+        result.extract(py).unwrap()
+    })
+}

--- a/pgml-extension/src/lib.rs
+++ b/pgml-extension/src/lib.rs
@@ -21,7 +21,22 @@ extension_sql_file!("../sql/schema.sql", name = "schema");
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pg_schema]
-mod tests {}
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_migration_file_exists() {
+        let paths = std::fs::read_dir("./sql").unwrap();
+        for path in paths {
+            let path = path.unwrap().path().display().to_string();
+            if path.contains(VERSION) {
+                return;
+            }
+        }
+
+        panic!("Migration file for version {} not found", VERSION);
+    }
+}
 
 #[cfg(test)]
 pub mod pg_test {


### PR DESCRIPTION
1. Add `pgml.python_pip_freeze()` to help debug Python package versions used by PostgresML.
2. Add missing dependency installation for macOS.
3. Add test for missing migration file.