### PR TITLE
move postgres logging out of transformer module

### DIFF
--- a/pgml-extension/src/bindings/transformers/error.rs
+++ b/pgml-extension/src/bindings/transformers/error.rs
@@ -1,0 +1,44 @@
+use std::fmt;
+
+use pyo3::PyErr;
+
+use super::whitelist::WhitelistError;
+
+#[derive(Debug)]
+pub enum Error {
+    Serde(serde_json::Error),
+    Python(PyErr),
+    Model(WhitelistError),
+    Data(String),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Python(e) => write!(f, "{e}"),
+            Error::Model(e) => write!(f, "{e}"),
+            Error::Serde(e) => write!(f, "{e}"),
+            Error::Data(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<PyErr> for Error {
+    fn from(value: PyErr) -> Self {
+        Self::Python(value)
+    }
+}
+
+impl From<WhitelistError> for Error {
+    fn from(value: WhitelistError) -> Self {
+        Self::Model(value)
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(value: serde_json::Error) -> Self {
+        Self::Serde(value)
+    }
+}

--- a/pgml-extension/src/bindings/transformers/transformers.py
+++ b/pgml-extension/src/bindings/transformers/transformers.py
@@ -184,7 +184,13 @@ def transform(task, args, inputs):
         elif model_name and "-gptq" in model_name:
             pipe = GPTQPipeline(model_name, **task)
         else:
-            pipe = StandardPipeline(model_name, **task)
+            try:
+                pipe = StandardPipeline(model_name, **task)
+            except TypeError:
+                # some models fail when given "device" kwargs, remove and try again
+                task.pop("device")
+                pipe = StandardPipeline(model_name, **task)
+
         __cache_transform_pipeline_by_task[key] = pipe
 
     pipe = __cache_transform_pipeline_by_task[key]

--- a/pgml-extension/src/orm/model.rs
+++ b/pgml-extension/src/orm/model.rs
@@ -217,7 +217,10 @@ impl Model {
         let path = std::path::PathBuf::from(format!("/tmp/postgresml/models/{id}"));
 
         info!("Tuning {}", model);
-        let metrics = transformers::tune(&project.task, dataset, &model.hyperparams, &path);
+        let metrics = match transformers::tune(&project.task, dataset, &model.hyperparams, &path) {
+            Ok(metrics) => metrics,
+            Err(e) => error!("{e}"),
+        };
         model.metrics = Some(JsonB(json!(metrics)));
         info!("Metrics: {:?}", &metrics);
 


### PR DESCRIPTION
- Move postgres logging out of transformer module
  - postgres logging macros silently kill bg_worker process
- remove `device` from kwargs on TypeError in transform and try again