### PR TITLE
Fix panic when cluster isnt connected

### DIFF
--- a/pgml-dashboard/src/lib.rs
+++ b/pgml-dashboard/src/lib.rs
@@ -17,7 +17,7 @@ pub mod responses;
 pub mod templates;
 pub mod utils;
 
-use guards::Cluster;
+use guards::{Cluster, ConnectedCluster};
 use responses::{BadRequest, Error, ResponseOk};
 use templates::{
     components::StaticNav, DeploymentsTab, Layout, ModelsTab, NotebooksTab, ProjectsTab,
@@ -47,7 +47,7 @@ pub struct Context {
 }
 
 #[get("/projects")]
-pub async fn project_index(cluster: &Cluster) -> Result<ResponseOk, Error> {
+pub async fn project_index(cluster: ConnectedCluster<'_>) -> Result<ResponseOk, Error> {
     Ok(ResponseOk(
         templates::Projects {
             projects: models::Project::all(cluster.pool()).await?,
@@ -58,7 +58,7 @@ pub async fn project_index(cluster: &Cluster) -> Result<ResponseOk, Error> {
 }
 
 #[get("/projects/<id>")]
-pub async fn project_get(cluster: &Cluster, id: i64) -> Result<ResponseOk, Error> {
+pub async fn project_get(cluster: ConnectedCluster<'_>, id: i64) -> Result<ResponseOk, Error> {
     let project = models::Project::get_by_id(cluster.pool(), id).await?;
     let models = models::Model::get_by_project_id(cluster.pool(), id).await?;
 
@@ -70,7 +70,7 @@ pub async fn project_get(cluster: &Cluster, id: i64) -> Result<ResponseOk, Error
 }
 
 #[get("/notebooks")]
-pub async fn notebook_index(cluster: &Cluster) -> Result<ResponseOk, Error> {
+pub async fn notebook_index(cluster: ConnectedCluster<'_>) -> Result<ResponseOk, Error> {
     Ok(ResponseOk(
         templates::Notebooks {
             notebooks: models::Notebook::all(&cluster.pool()).await?,
@@ -94,7 +94,10 @@ pub async fn notebook_create(
 }
 
 #[get("/notebooks/<notebook_id>")]
-pub async fn notebook_get(cluster: &Cluster, notebook_id: i64) -> Result<ResponseOk, Error> {
+pub async fn notebook_get(
+    cluster: ConnectedCluster<'_>,
+    notebook_id: i64,
+) -> Result<ResponseOk, Error> {
     let notebook = models::Notebook::get_by_id(cluster.pool(), notebook_id).await?;
 
     Ok(ResponseOk(Layout::new("Notebooks").render(
@@ -106,7 +109,10 @@ pub async fn notebook_get(cluster: &Cluster, notebook_id: i64) -> Result<Respons
 }
 
 #[post("/notebooks/<notebook_id>/reset")]
-pub async fn notebook_reset(cluster: &Cluster, notebook_id: i64) -> Result<Redirect, Error> {
+pub async fn notebook_reset(
+    cluster: ConnectedCluster<'_>,
+    notebook_id: i64,
+) -> Result<Redirect, Error> {
     let notebook = models::Notebook::get_by_id(cluster.pool(), notebook_id).await?;
     notebook.reset(cluster.pool()).await?;
 
@@ -140,7 +146,7 @@ pub async fn cell_create(
 
 #[get("/notebooks/<notebook_id>/cell/<cell_id>")]
 pub async fn cell_get(
-    cluster: &Cluster,
+    cluster: ConnectedCluster<'_>,
     notebook_id: i64,
     cell_id: i64,
 ) -> Result<ResponseOk, Error> {
@@ -167,7 +173,7 @@ pub async fn cell_get(
 
 #[post("/notebooks/<notebook_id>/cell/<cell_id>/edit", data = "<data>")]
 pub async fn cell_edit(
-    cluster: &Cluster,
+    cluster: ConnectedCluster<'_>,
     notebook_id: i64,
     cell_id: i64,
     data: Form<forms::Cell<'_>>,
@@ -203,7 +209,7 @@ pub async fn cell_edit(
 
 #[get("/notebooks/<notebook_id>/cell/<cell_id>/edit")]
 pub async fn cell_trigger_edit(
-    cluster: &Cluster,
+    cluster: ConnectedCluster<'_>,
     notebook_id: i64,
     cell_id: i64,
 ) -> Result<ResponseOk, Error> {
@@ -229,7 +235,7 @@ pub async fn cell_trigger_edit(
 
 #[post("/notebooks/<notebook_id>/cell/<cell_id>/play")]
 pub async fn cell_play(
-    cluster: &Cluster,
+    cluster: ConnectedCluster<'_>,
     notebook_id: i64,
     cell_id: i64,
 ) -> Result<ResponseOk, Error> {
@@ -256,7 +262,7 @@ pub async fn cell_play(
 
 #[post("/notebooks/<notebook_id>/cell/<cell_id>/remove")]
 pub async fn cell_remove(
-    cluster: &Cluster,
+    cluster: ConnectedCluster<'_>,
     notebook_id: i64,
     cell_id: i64,
 ) -> Result<ResponseOk, Error> {
@@ -279,7 +285,7 @@ pub async fn cell_remove(
 
 #[post("/notebooks/<notebook_id>/cell/<cell_id>/delete")]
 pub async fn cell_delete(
-    cluster: &Cluster,
+    cluster: ConnectedCluster<'_>,
     notebook_id: i64,
     cell_id: i64,
 ) -> Result<Redirect, Error> {
@@ -295,7 +301,7 @@ pub async fn cell_delete(
 }
 
 #[get("/models")]
-pub async fn models_index(cluster: &Cluster) -> Result<ResponseOk, Error> {
+pub async fn models_index(cluster: ConnectedCluster<'_>) -> Result<ResponseOk, Error> {
     let projects = models::Project::all(cluster.pool()).await?;
     let mut models = HashMap::new();
     // let mut max_scores = HashMap::new();
@@ -328,7 +334,7 @@ pub async fn models_index(cluster: &Cluster) -> Result<ResponseOk, Error> {
 }
 
 #[get("/models/<id>")]
-pub async fn models_get(cluster: &Cluster, id: i64) -> Result<ResponseOk, Error> {
+pub async fn models_get(cluster: ConnectedCluster<'_>, id: i64) -> Result<ResponseOk, Error> {
     let model = models::Model::get_by_id(cluster.pool(), id).await?;
     let snapshot = models::Snapshot::get_by_id(cluster.pool(), model.snapshot_id).await?;
     let project = models::Project::get_by_id(cluster.pool(), model.project_id).await?;
@@ -346,7 +352,7 @@ pub async fn models_get(cluster: &Cluster, id: i64) -> Result<ResponseOk, Error>
 }
 
 #[get("/snapshots")]
-pub async fn snapshots_index(cluster: &Cluster) -> Result<ResponseOk, Error> {
+pub async fn snapshots_index(cluster: ConnectedCluster<'_>) -> Result<ResponseOk, Error> {
     let snapshots = models::Snapshot::all(cluster.pool()).await?;
 
     Ok(ResponseOk(
@@ -355,7 +361,7 @@ pub async fn snapshots_index(cluster: &Cluster) -> Result<ResponseOk, Error> {
 }
 
 #[get("/snapshots/<id>")]
-pub async fn snapshots_get(cluster: &Cluster, id: i64) -> Result<ResponseOk, Error> {
+pub async fn snapshots_get(cluster: ConnectedCluster<'_>, id: i64) -> Result<ResponseOk, Error> {
     let snapshot = models::Snapshot::get_by_id(cluster.pool(), id).await?;
     let samples = snapshot.samples(cluster.pool(), 500).await?;
 
@@ -379,7 +385,7 @@ pub async fn snapshots_get(cluster: &Cluster, id: i64) -> Result<ResponseOk, Err
 }
 
 #[get("/deployments")]
-pub async fn deployments_index(cluster: &Cluster) -> Result<ResponseOk, Error> {
+pub async fn deployments_index(cluster: ConnectedCluster<'_>) -> Result<ResponseOk, Error> {
     let projects = models::Project::all(cluster.pool()).await?;
     let mut deployments = HashMap::new();
 
@@ -401,7 +407,7 @@ pub async fn deployments_index(cluster: &Cluster) -> Result<ResponseOk, Error> {
 }
 
 #[get("/deployments/<id>")]
-pub async fn deployments_get(cluster: &Cluster, id: i64) -> Result<ResponseOk, Error> {
+pub async fn deployments_get(cluster: ConnectedCluster<'_>, id: i64) -> Result<ResponseOk, Error> {
     let deployment = models::Deployment::get_by_id(cluster.pool(), id).await?;
     let project = models::Project::get_by_id(cluster.pool(), deployment.project_id).await?;
     let model = models::Model::get_by_id(cluster.pool(), deployment.model_id).await?;
@@ -424,7 +430,7 @@ pub async fn uploader_index() -> ResponseOk {
 
 #[post("/uploader", data = "<form>")]
 pub async fn uploader_upload(
-    cluster: &Cluster,
+    cluster: ConnectedCluster<'_>,
     form: Form<forms::Upload<'_>>,
 ) -> Result<Redirect, BadRequest> {
     let mut uploaded_file = models::UploadedFile::create(cluster.pool()).await.unwrap();
@@ -446,7 +452,7 @@ pub async fn uploader_upload(
 }
 
 #[get("/uploader/done?<table_name>")]
-pub async fn uploaded_index(cluster: &Cluster, table_name: &str) -> ResponseOk {
+pub async fn uploaded_index(cluster: ConnectedCluster<'_>, table_name: &str) -> ResponseOk {
     let sql = templates::Sql::new(
         cluster.pool(),
         &format!("SELECT * FROM {} LIMIT 10", table_name),


### PR DESCRIPTION
Return a 404 Page Not Found instead of crashing with 500 Internal Server Error when requesting a dashboard page for a cluster that doesn't have a connection pool. This was causing Sentry reports that weren't really actionable. We should hide the Dashboard link from databases that aren't online.

We should really rename `Cluster` to something else also, e.g. `Context`.