### PR TITLE
Fix clear_gpu_cache

### DIFF
--- a/pgml-extension/requirements.txt
+++ b/pgml-extension/requirements.txt
@@ -25,3 +25,4 @@ transformers==4.31.0
 xgboost==1.7.6
 langchain==0.0.237
 einops==0.6.1
+pynvml==11.5.0

--- a/pgml-extension/src/bindings/transformers/mod.rs
+++ b/pgml-extension/src/bindings/transformers/mod.rs
@@ -348,6 +348,8 @@ pub fn load_dataset(
 }
 
 pub fn clear_gpu_cache(memory_usage: Option<f32>) -> Result<bool> {
+    crate::bindings::venv::activate();
+
     Python::with_gil(|py| -> Result<bool> {
         let clear_gpu_cache: Py<PyAny> = PY_MODULE.getattr(py, "clear_gpu_cache")?;
         let success = clear_gpu_cache


### PR DESCRIPTION
1. We have a missing dependency.
2. `clear_gpu_cache` was not activating the virtual environment.