### PR TITLE
Remove validate_python_dependencies when create extension

### DIFF
--- a/pgml-extension/sql/schema.sql
+++ b/pgml-extension/sql/schema.sql
@@ -1,7 +1,3 @@
----
---- Validate we have the necessary Python dependencies.
----
-SELECT pgml.validate_python_dependencies();
 SELECT pgml.validate_shared_library();
 
 --- 


### PR DESCRIPTION
The python dependencies could be installed in the virtual env. However,
the 'pgml.activate_venv()' will be available after the 'CREATE
EXTENSION' statement.

In this situation, the `CREATE EXTENSION` always fails and user doesn't
have a chance to set the venv.

Also, the python dependencies could be removed at any time after the
extension creation. A validation at the beginning is not quite useful.
