### PR TITLE
100% CPU usage in the dashboard fix

### DIFF
--- a/pgml-dashboard/src/guards.rs
+++ b/pgml-dashboard/src/guards.rs
@@ -6,7 +6,7 @@ use rocket::request::{self, FromRequest, Request};
 use sqlx::{postgres::PgPoolOptions, Executor, PgPool};
 
 use crate::models;
-use crate::{ClustersSettings, Context};
+use crate::Context;
 
 pub fn default_database_url() -> String {
     match var("DATABASE_URL") {
@@ -25,20 +25,13 @@ impl Default for Cluster {
     fn default() -> Self {
         let max_connections = 1;
         let min_connections = 1;
-        let idle_timeout = 0;
-
-        let settings = ClustersSettings {
-            max_connections,
-            idle_timeout,
-            min_connections,
-        };
 
         Cluster {
             pool: Some(
                 PgPoolOptions::new()
-                    .max_connections(settings.max_connections)
-                    .idle_timeout(std::time::Duration::from_millis(settings.idle_timeout))
-                    .min_connections(settings.min_connections)
+                    .max_connections(max_connections)
+                    .idle_timeout(None)
+                    .min_connections(min_connections)
                     .after_connect(|conn, _meta| {
                         Box::pin(async move {
                             conn.execute("SET application_name = 'pgml_dashboard';")


### PR DESCRIPTION
SQLx polls every 0s, which makes the task constantly being awoken to check the `idle_timeout`. `None` makes it not poll for idle timeouts at all, which is what we want. Debugged with the awesome `tokio-console`.