### PR TITLE
remove 0 if step is whole number

### DIFF
--- a/pgml-dashboard/src/components/inputs/range_group/template.html
+++ b/pgml-dashboard/src/components/inputs/range_group/template.html
@@ -22,7 +22,7 @@
     min="<%- min %>"
     max="<%- max %>"
     step="<%- step %>"
-    value="<%- initial_value %>"
+    value="<%- initial_value.to_string() %>"
     data-action="inputs-range-group#updateText" 
     data-inputs-range-group-target="range"
     <% if range_target.is_some() { %><%- range_target.unwrap() %><% } %>>


### PR DESCRIPTION
 - converting to a string removes trailing zeroes on floats. 

![Screenshot 2023-09-14 at 5 58 07 PM](https://github.com/postgresml/postgresml/assets/39170265/9345c789-8e55-4cc2-9363-ad5e531348b2)
