### PR TITLE
Dont crash the dashboard if search index is not built

### DIFF
--- a/pgml-dashboard/src/utils/markdown.rs
+++ b/pgml-dashboard/src/utils/markdown.rs
@@ -1196,11 +1196,11 @@ impl SearchIndex {
         let path = Self::path();
 
         if !path.exists() {
-            std::fs::create_dir(Self::path())
+            std::fs::create_dir(&path)
                 .expect("failed to create search_index directory, is the filesystem writable?");
         }
 
-        let index = match tantivy::Index::open_in_dir(&Self::path()) {
+        let index = match tantivy::Index::open_in_dir(&path) {
             Ok(index) => index,
             Err(err) => {
                 warn!(
@@ -1208,7 +1208,7 @@ impl SearchIndex {
                     path.display(),
                     err
                 );
-                Index::create_in_dir(&Self::path(), Self::schema())?
+                Index::create_in_dir(&path, Self::schema())?
             }
         };
 

--- a/pgml-dashboard/src/utils/markdown.rs
+++ b/pgml-dashboard/src/utils/markdown.rs
@@ -1193,7 +1193,24 @@ impl SearchIndex {
     }
 
     pub fn open() -> tantivy::Result<SearchIndex> {
-        let index = tantivy::Index::open_in_dir(&Self::path())?;
+        let path = Self::path();
+
+        if !path.exists() {
+            std::fs::create_dir(Self::path())
+                .expect("failed to create search_index directory, is the filesystem writable?");
+        }
+
+        let index = match tantivy::Index::open_in_dir(&Self::path()) {
+            Ok(index) => index,
+            Err(err) => {
+                warn!(
+                    "Failed to open Tantivy index in '{}', creating an empty one, error: {}",
+                    path.display(),
+                    err
+                );
+                Index::create_in_dir(&Self::path(), Self::schema())?
+            }
+        };
 
         let reader = index.reader_builder().try_into()?;
 


### PR DESCRIPTION
1. This is kinda annoying since while really important, searching is not the only functionality the app provides, so if we don't have the search index built for any reason, we should not just crash.
2. Useful for testing. The search index is not necessary for tests and it's a bit time consuming to build for each integration test.