### PR TITLE
Add node resolver to pgml-components

### DIFF
--- a/pgml-apps/cargo-pgml-components/Cargo.lock
+++ b/pgml-apps/cargo-pgml-components/Cargo.lock
@@ -141,6 +141,8 @@ dependencies = [
  "predicates",
  "regex",
  "sailfish",
+ "serde",
+ "toml",
 ]
 
 [[package]]

--- a/pgml-apps/cargo-pgml-components/Cargo.lock
+++ b/pgml-apps/cargo-pgml-components/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgml-components"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/pgml-apps/cargo-pgml-components/Cargo.toml
+++ b/pgml-apps/cargo-pgml-components/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pgml-components"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 authors = ["PostgresML <team@postgresml.org>"]
 license = "MIT"

--- a/pgml-apps/cargo-pgml-components/Cargo.toml
+++ b/pgml-apps/cargo-pgml-components/Cargo.toml
@@ -19,6 +19,8 @@ anyhow = "1"
 owo-colors = "3"
 sailfish = "0.8"
 regex = "1"
+toml = "0.7"
+serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/pgml-apps/cargo-pgml-components/src/config.rs
+++ b/pgml-apps/cargo-pgml-components/src/config.rs
@@ -1,0 +1,33 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Default, Clone)]
+pub struct Javascript {
+    #[serde(default = "Javascript::default_additional_paths")]
+    pub additional_paths: Vec<String>,
+}
+
+impl Javascript {
+    fn default_additional_paths() -> Vec<String> {
+        vec![]
+    }
+}
+
+#[derive(Serialize, Deserialize, Default, Clone)]
+pub struct Config {
+    pub javascript: Javascript,
+}
+
+impl Config {
+    pub fn from_path(path: &str) -> anyhow::Result<Config> {
+        let config_str = std::fs::read_to_string(path)?;
+        let config: Config = toml::from_str(&config_str)?;
+        Ok(config)
+    }
+
+    pub fn load() -> Config {
+        match Self::from_path("pgml-components.toml") {
+            Ok(config) => config,
+            Err(_) => Config::default(),
+        }
+    }
+}

--- a/pgml-apps/cargo-pgml-components/src/frontend/components.rs
+++ b/pgml-apps/cargo-pgml-components/src/frontend/components.rs
@@ -205,8 +205,7 @@ fn update_module(path: &Path) {
     debug!("writing {} modules to mod.rs", modules.len());
 
     let components_mod = path.join("mod.rs");
-    let modules =
-        unwrap_or_exit!(templates::Mod { modules }.render_once()).replace("\n\n", "\n");
+    let modules = unwrap_or_exit!(templates::Mod { modules }.render_once()).replace("\n\n", "\n");
 
     let existing_modules = if components_mod.is_file() {
         unwrap_or_exit!(read_to_string(&components_mod))

--- a/pgml-apps/cargo-pgml-components/src/frontend/components.rs
+++ b/pgml-apps/cargo-pgml-components/src/frontend/components.rs
@@ -191,10 +191,7 @@ fn update_module(path: &Path) {
         }
 
         if has_more_modules(&path) {
-            debug!("{} has more modules", path.display());
             update_module(&path);
-        } else {
-            debug!("it does not really no");
         }
 
         let component_path = path.components().skip(2).collect::<PathBuf>();
@@ -219,7 +216,7 @@ fn update_module(path: &Path) {
         info(&format!("written {}", components_mod.display().to_string()));
     }
 
-    debug!("mod.rs is the same");
+    debug!("{}/mod.rs is different", components_mod.display());
 }
 
 /// Check that the path has more Rust modules.
@@ -227,7 +224,7 @@ fn has_more_modules(path: &Path) -> bool {
     debug!("checking if {} has more modules", path.display());
 
     if !path.exists() {
-        debug!("path does not exist");
+        debug!("path {} does not exist", path.display());
         return false;
     }
 
@@ -243,13 +240,12 @@ fn has_more_modules(path: &Path) -> bool {
 
         if let Some(file_name) = path.file_name() {
             if file_name != "mod.rs" {
-                debug!("it has another file that's not mod.rs");
+                debug!("{} has another file that's not mod.rs", path.display());
                 return false;
             }
         }
     }
 
-    debug!("it does");
     true
 }
 

--- a/pgml-apps/cargo-pgml-components/src/frontend/tools.rs
+++ b/pgml-apps/cargo-pgml-components/src/frontend/tools.rs
@@ -7,6 +7,7 @@ use std::process::{exit, Command};
 
 /// Required tools.
 static TOOLS: &[&str] = &["sass", "rollup"];
+static ROLLUP_PLUGINS: &[&str] = &["@rollup/plugin-terser", "@rollup/plugin-node-resolve"];
 static NVM_EXEC: &'static str = "/tmp/pgml-components-nvm.sh";
 static NVM_SOURCE: &'static str = "https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh";
 static NVM_SOURCE_DOWNLOADED: &'static str = "/tmp/pgml-components-nvm-source.sh";
@@ -28,6 +29,22 @@ pub fn install() {
                     Command::new("npm").arg("install").arg("-g").arg(tool)
                 ));
             }
+        }
+    }
+
+    for plugin in ROLLUP_PLUGINS {
+        if execute_with_nvm(
+            Command::new("rollup")
+                .arg("-p")
+                .arg(plugin)
+                .arg("--version"),
+        )
+        .is_err()
+        {
+            warn(&format!("installing rollup plugin {}", plugin));
+            unwrap_or_exit!(execute_with_nvm(
+                Command::new("npm").arg("install").arg("-g").arg(plugin)
+            ));
         }
     }
 }

--- a/pgml-apps/cargo-pgml-components/src/frontend/tools.rs
+++ b/pgml-apps/cargo-pgml-components/src/frontend/tools.rs
@@ -1,8 +1,9 @@
 //! Tools required by us to build stuff.
 
-use crate::util::{debug1, error, execute_command, unwrap_or_exit, warn};
+use crate::util::{debug1, error, execute_command, info, unwrap_or_exit, warn};
 use std::fs::File;
 use std::io::Write;
+use std::path::Path;
 use std::process::{exit, Command};
 
 /// Required tools.
@@ -46,6 +47,11 @@ pub fn install() {
                 Command::new("npm").arg("install").arg("-g").arg(plugin)
             ));
         }
+    }
+
+    if Path::new("package.json").exists() {
+        info("installing dependencies from package.json");
+        unwrap_or_exit!(execute_with_nvm(Command::new("npm").arg("install")));
     }
 }
 

--- a/pgml-apps/cargo-pgml-components/src/util.rs
+++ b/pgml-apps/cargo-pgml-components/src/util.rs
@@ -39,6 +39,8 @@ pub fn warn(value: &str) {
 }
 
 pub fn execute_command(command: &mut Command) -> std::io::Result<String> {
+    debug!("Executing {:?}", command);
+
     let output = match command.output() {
         Ok(output) => output,
         Err(err) => {


### PR DESCRIPTION
1. Add `@rollup/plugin-node-resolve` to Rollup so we can include dependencies from package.json into the bundle!
2. Add optional `@rollup/plugin-terser` to Rollup for production bundle minification.
3. Add a config file that can specify additional paths for glob to find javascript controllers.