### PR TITLE
Check for plugins better

### DIFF
--- a/pgml-apps/cargo-pgml-components/Cargo.lock
+++ b/pgml-apps/cargo-pgml-components/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgml-components"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/pgml-apps/cargo-pgml-components/Cargo.toml
+++ b/pgml-apps/cargo-pgml-components/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pgml-components"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 authors = ["PostgresML <team@postgresml.org>"]
 license = "MIT"

--- a/pgml-apps/cargo-pgml-components/src/frontend/nvm.sh
+++ b/pgml-apps/cargo-pgml-components/src/frontend/nvm.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
-[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 
-${@}
+exec ${@}

--- a/pgml-apps/cargo-pgml-components/src/frontend/tools.rs
+++ b/pgml-apps/cargo-pgml-components/src/frontend/tools.rs
@@ -35,10 +35,10 @@ pub fn install() {
 
     for plugin in ROLLUP_PLUGINS {
         if execute_with_nvm(
-            Command::new("rollup")
-                .arg("-p")
+            Command::new("npm")
+                .arg("list")
+                .arg("-g")
                 .arg(plugin)
-                .arg("--version"),
         )
         .is_err()
         {


### PR DESCRIPTION
1. Check for plugins using `npm list -g` which works much better.
2. Remove unnecessary bash from the nvm entrypoint & use `exec`.