### PR TITLE
Dan fix webapp content area

### DIFF
--- a/pgml-dashboard/src/api/chatbot.rs
+++ b/pgml-dashboard/src/api/chatbot.rs
@@ -121,7 +121,13 @@ struct Document {
 }
 
 impl Document {
-    fn new(text: String, role: ChatRole, user_id: String, model: ChatbotBrain, knowledge_base: KnowledgeBase) -> Document {
+    fn new(
+        text: String,
+        role: ChatRole,
+        user_id: String,
+        model: ChatbotBrain,
+        knowledge_base: KnowledgeBase,
+    ) -> Document {
         let id = rand::thread_rng()
             .sample_iter(&Alphanumeric)
             .take(32)
@@ -225,7 +231,7 @@ pub async fn wrapped_chatbot_get_answer(
         ChatRole::User,
         user.chatbot_session_id.clone(),
         brain,
-        knowledge_base
+        knowledge_base,
     );
 
     let collection = knowledge_base.collection();
@@ -317,7 +323,7 @@ pub async fn wrapped_chatbot_get_answer(
             ChatRole::Bot,
             user.chatbot_session_id.clone(),
             brain,
-            knowledge_base
+            knowledge_base,
         ))
         .unwrap()
         .into(),
@@ -327,7 +333,8 @@ pub async fn wrapped_chatbot_get_answer(
     tokio::spawn(async move {
         history_collection
             .upsert_documents(new_history_messages, None)
-            .await.expect("Failed to upsert user history");
+            .await
+            .expect("Failed to upsert user history");
     });
 
     Ok(answer)

--- a/pgml-dashboard/src/components/chatbot/mod.rs
+++ b/pgml-dashboard/src/components/chatbot/mod.rs
@@ -10,30 +10,42 @@ use sailfish::TemplateOnce;
 
 type ExampleQuestions = [(&'static str, [(&'static str, &'static str); 4]); 4];
 const EXAMPLE_QUESTIONS: ExampleQuestions = [
-    ("PostgresML", [
-        ("PostgresML", "sample question continued"),
-        ("PostgresML", "sample question continued"),
-        ("PostgresML", "sample question continued"),
-        ("PostgresML", "sample question continued"),
-    ]),
-    ("PyTorch", [
-        ("PyTorch", "sample question continued"),
-        ("PyTorch", "sample question continued"),
-        ("PyTorch", "sample question continued"),
-        ("PyTorch", "sample question continued"),
-    ]),
-    ("Rust", [
-        ("Rust", "sample question continued"),
-        ("Rust", "sample question continued"),
-        ("Rust", "sample question continued"),
-        ("Rust", "sample question continued"),
-    ]),
-    ("PostgreSQL", [
-        ("PostgreSQL", "sample question continued"),
-        ("PostgreSQL", "sample question continued"),
-        ("PostgreSQL", "sample question continued"),
-        ("PostgreSQL", "sample question continued"),
-    ]),
+    (
+        "PostgresML",
+        [
+            ("PostgresML", "sample question continued"),
+            ("PostgresML", "sample question continued"),
+            ("PostgresML", "sample question continued"),
+            ("PostgresML", "sample question continued"),
+        ],
+    ),
+    (
+        "PyTorch",
+        [
+            ("PyTorch", "sample question continued"),
+            ("PyTorch", "sample question continued"),
+            ("PyTorch", "sample question continued"),
+            ("PyTorch", "sample question continued"),
+        ],
+    ),
+    (
+        "Rust",
+        [
+            ("Rust", "sample question continued"),
+            ("Rust", "sample question continued"),
+            ("Rust", "sample question continued"),
+            ("Rust", "sample question continued"),
+        ],
+    ),
+    (
+        "PostgreSQL",
+        [
+            ("PostgreSQL", "sample question continued"),
+            ("PostgreSQL", "sample question continued"),
+            ("PostgreSQL", "sample question continued"),
+            ("PostgreSQL", "sample question continued"),
+        ],
+    ),
 ];
 
 const KNOWLEDGE_BASES: [&'static str; 0] = [
@@ -44,18 +56,9 @@ const KNOWLEDGE_BASES: [&'static str; 0] = [
 ];
 
 const KNOWLEDGE_BASES_WITH_LOGO: [KnowledgeBaseWithLogo; 4] = [
-    KnowledgeBaseWithLogo::new(
-        "PostgresML",
-        "/dashboard/static/images/owl_gradient.svg",
-    ),
-    KnowledgeBaseWithLogo::new(
-        "PyTorch",
-        "/dashboard/static/images/logos/pytorch.svg",
-    ),
-    KnowledgeBaseWithLogo::new(
-        "Rust",
-        "/dashboard/static/images/logos/rust.svg",
-    ),
+    KnowledgeBaseWithLogo::new("PostgresML", "/dashboard/static/images/owl_gradient.svg"),
+    KnowledgeBaseWithLogo::new("PyTorch", "/dashboard/static/images/logos/pytorch.svg"),
+    KnowledgeBaseWithLogo::new("Rust", "/dashboard/static/images/logos/rust.svg"),
     KnowledgeBaseWithLogo::new(
         "PostgreSQL",
         "/dashboard/static/images/logos/postgresql.svg",

--- a/pgml-dashboard/src/components/star/mod.rs
+++ b/pgml-dashboard/src/components/star/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
-use pgml_components::component;
 use once_cell::sync::Lazy;
+use pgml_components::component;
 use sailfish::TemplateOnce;
 
 #[derive(TemplateOnce, Default)]

--- a/pgml-dashboard/static/css/scss/abstracts/variables.scss
+++ b/pgml-dashboard/static/css/scss/abstracts/variables.scss
@@ -243,6 +243,7 @@ $breadcrumb-padding-x:              4px;
 $breadcrumb-item-padding-x:         4px;
 $breadcrumb-margin-bottom:          0px;
 $breadcrumb-divider:                quote("");
+$breadcrumb-height:                 57px;
 
 // animations
 $animation-timer: 0.35s;

--- a/pgml-dashboard/static/css/scss/abstracts/variables.scss
+++ b/pgml-dashboard/static/css/scss/abstracts/variables.scss
@@ -209,6 +209,9 @@ $nav-pills-border-radius: calc(#{$border-radius} / 2);
 $left-nav-w: 17rem;
 $left-nav-w-collapsed: 88px;
 
+// WebApp Content Container
+$webapp-content-max-width: 1224px;
+
 //Grid
 $enable-cssgrid: true;
 $enable-shadows: true;

--- a/pgml-dashboard/static/css/scss/components/_navs.scss
+++ b/pgml-dashboard/static/css/scss/components/_navs.scss
@@ -9,7 +9,7 @@
     height: $navbar-height;
     position: fixed; 
     top: 0px;
-    z-index: $zindex-fixed;
+    z-index: calc($zindex-fixed + 1);
 }
 
 .navbar {

--- a/pgml-dashboard/static/css/scss/layout/_containers.scss
+++ b/pgml-dashboard/static/css/scss/layout/_containers.scss
@@ -149,5 +149,5 @@
 .webapp-content-max-width-container {
     max-width: $webapp-content-max-width;
     margin-left: 0px;
-    min-height: calc(100vh - $navbar-height - 1px);
+    min-height: calc(100vh - $navbar-height - $breadcrumb-height - 1px);
   }

--- a/pgml-dashboard/static/css/scss/layout/_containers.scss
+++ b/pgml-dashboard/static/css/scss/layout/_containers.scss
@@ -145,3 +145,9 @@
         width: $left-nav-w;
     }
 }
+
+.webapp-content-max-width-container {
+    max-width: $webapp-content-max-width;
+    margin-left: 0px;
+    min-height: calc(100vh - $navbar-height - 1px);
+  }

--- a/pgml-dashboard/templates/content/dashboard/panels/notebooks.html
+++ b/pgml-dashboard/templates/content/dashboard/panels/notebooks.html
@@ -1,18 +1,18 @@
 <turbo-frame id="notebooks">
-  <div class="pb-5">
+  <div class="pb-5 position-relative">
     <div style="width: 526px;
         height: 433px; 
         max-width: 50vw; 
-        position:relative; 
+        position: absolute; 
         left: 50%;
-        top: 93px;
+        top: calc(50% - 216px);
         transform: translateX(-50%);
         border-radius: 752px;
         background: radial-gradient(46.38% 45.17% at 22.72% 36.90%, rgba(57, 210, 231, 0.60) 26.40%, rgba(174, 110, 255, 0.60) 100%);
         filter: blur(252.66856384277344px);">
     </div>
     <% if !notebooks.is_empty() { %>
-    <div class="row gx-4 gy-4 position-relative" style="margin-top: -433px;">
+    <div class="row gx-4 gy-4 position-relative">
       <% for notebook in notebooks { %>
       <div class="col-12 col-md-6 col-xxl-4">
         <div class="card h-100">

--- a/pgml-dashboard/templates/layout/web_app_base.html
+++ b/pgml-dashboard/templates/layout/web_app_base.html
@@ -36,8 +36,8 @@
                                 <%- Breadcrumbs::render( breadcrumbs ) %>
                             </div>
 
-                            <div class="px-xs-2 px-md-5 overflow-auto" style="padding-top: 57px;">
-                                <div class="webapp-content-max-width-container">
+                            <div class="px-xs-2 px-md-5 overflow-hidden" style="padding-top: 57px;">
+                                <div class="webapp-content-max-width-container pt-4">
                                     <%- content.unwrap_or_default() %>
                                 </div>
                             </div>

--- a/pgml-dashboard/templates/layout/web_app_base.html
+++ b/pgml-dashboard/templates/layout/web_app_base.html
@@ -32,12 +32,14 @@
                         </div>
     
                         <div class="clear-from-under-navbar flex-grow-1 min-vw-0">
-                            <div class="px-5 py-3">
+                            <div class="px-5 py-3" style="position: absolute">
                                 <%- Breadcrumbs::render( breadcrumbs ) %>
                             </div>
 
-                            <div class="px-xs-2 px-md-5 pt-2 mb-2 overflow-auto">
-                                <%- content.unwrap_or_default() %>
+                            <div class="px-xs-2 px-md-5 overflow-auto" style="padding-top: 57px;">
+                                <div class="webapp-content-max-width-container">
+                                    <%- content.unwrap_or_default() %>
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
 - allow glow to go under breadcrumb and be positioned by percent of parent size, not vw, but not cause scrolling in x or y direction.
 - remove negative margins 
 - format
![Screenshot 2023-10-09 at 2 59 18 PM](https://github.com/postgresml/postgresml/assets/39170265/2fca9298-0dca-452e-a062-d0d2b897fee7)
