### PR TITLE
Fix docs search

### DIFF
--- a/pgml-dashboard/src/components/accordian/mod.rs
+++ b/pgml-dashboard/src/components/accordian/mod.rs
@@ -1,5 +1,5 @@
-use sailfish::TemplateOnce;
 use pgml_components::component;
+use sailfish::TemplateOnce;
 
 // This component will probably not work very well if two are on the same page at once. We can get
 // around it if we include some randomness with the data values in the template.html but that
@@ -10,7 +10,7 @@ use pgml_components::component;
 pub struct Accordian {
     html_contents: Vec<String>,
     html_titles: Vec<String>,
-    selected: usize
+    selected: usize,
 }
 
 impl Accordian {

--- a/pgml-dashboard/src/components/accordian/template.html
+++ b/pgml-dashboard/src/components/accordian/template.html
@@ -1,8 +1,7 @@
-<% use std::iter::zip; %>
 
 <div data-controller="accordian">
   <div class="accordian">
-    <% for i in (0..html_contents.len()) { %>
+    <% for i in 0..html_contents.len() { %>
       <div class="accordian-item">
         <div class="accordian-header <% if i == selected { %> selected <% } %>" data-action="click->accordian#titleClick" data-value="accordian-body<%= i %>">
           <%- html_titles[i] %>

--- a/pgml-dashboard/src/components/inputs/range_group/mod.rs
+++ b/pgml-dashboard/src/components/inputs/range_group/mod.rs
@@ -1,6 +1,6 @@
+use crate::components::stimulus::stimulus_target::StimulusTarget;
 use pgml_components::component;
 use sailfish::TemplateOnce;
-use crate::components::stimulus::stimulus_target::StimulusTarget;
 
 #[derive(TemplateOnce, Default)]
 #[template(path = "inputs/range_group/template.html")]

--- a/pgml-dashboard/src/lib.rs
+++ b/pgml-dashboard/src/lib.rs
@@ -1,14 +1,10 @@
 #[macro_use]
 extern crate rocket;
 
-use rand::{distributions::Alphanumeric, Rng};
+use rocket::form::Form;
 use rocket::response::Redirect;
 use rocket::route::Route;
 use rocket::serde::json::Json;
-use rocket::{
-    form::Form,
-    http::{Cookie, CookieJar},
-};
 use sailfish::TemplateOnce;
 use sqlx::PgPool;
 use std::collections::HashMap;

--- a/pgml-dashboard/src/utils/config.rs
+++ b/pgml-dashboard/src/utils/config.rs
@@ -42,7 +42,7 @@ pub fn blogs_dir() -> String {
 }
 
 pub fn docs_dir() -> String {
-    match var("DASHBOARD_DOCS_DIRECTORY") {
+    match var("DASHBOARD_CONTENT_DIRECTORY") {
         Ok(dir) => dir,
         Err(_) => "../pgml-docs/".to_string(),
     }

--- a/pgml-dashboard/src/utils/markdown.rs
+++ b/pgml-dashboard/src/utils/markdown.rs
@@ -1340,7 +1340,8 @@ impl SearchIndex {
     }
 
     pub fn documents() -> Vec<PathBuf> {
-        let guides = glob::glob(&(config::docs_dir() + "/guides/**/*.md")).expect("glob failed");
+        let guides =
+            glob::glob(&(config::docs_dir() + "/docs/guides/**/*.md")).expect("glob failed");
         let blogs = glob::glob(&(config::blogs_dir() + "/blog/**/*.md")).expect("glob failed");
         guides
             .chain(blogs)
@@ -1406,7 +1407,9 @@ impl SearchIndex {
                 .split("content")
                 .last()
                 .unwrap()
-                .to_string();
+                .to_string()
+                .replace("README", "")
+                .replace(&config::docs_dir(), "/");
             let mut doc = Document::default();
             doc.add_text(title_field, &title_text);
             doc.add_text(body_field, &body_text);


### PR DESCRIPTION
1. Fix new docs not being indexed by tentivy. cc @montanalow 
2. Fix a few compilation warnings.
3. `cargo fmt` cc @SilasMarvin 