### PR TITLE
Fix docs directory env

### DIFF
--- a/pgml-dashboard/src/utils/config.rs
+++ b/pgml-dashboard/src/utils/config.rs
@@ -42,7 +42,7 @@ pub fn blogs_dir() -> String {
 }
 
 pub fn docs_dir() -> String {
-    match var("DASHBOARD_CONTENT_DIRECTORY") {
+    match var("DASHBOARD_DOCS_DIRECTORY") {
         Ok(dir) => dir,
         Err(_) => "../pgml-docs/".to_string(),
     }


### PR DESCRIPTION
1. Accidental rename of the env var for docs directory.