### PR TITLE
Release 2.7.10

### DIFF
--- a/.github/workflows/ubuntu-packages-and-docker-image.yml
+++ b/.github/workflows/ubuntu-packages-and-docker-image.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       packageVersion:
-        default: "2.7.6"
+        default: "2.7.10"
 jobs:
   #
   # PostgresML extension.

--- a/.github/workflows/ubuntu-postgresml-python-package.yaml
+++ b/.github/workflows/ubuntu-postgresml-python-package.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       packageVersion:
-        default: "2.7.4"
+        default: "2.7.10"
 
 jobs:
   postgresml-python:

--- a/packages/postgresml-python/build.sh
+++ b/packages/postgresml-python/build.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 deb_dir="/tmp/postgresml-python/deb-build"
 major=${1:-"14"}
 
-export PACKAGE_VERSION=${1:-"2.7.4"}
+export PACKAGE_VERSION=${1:-"2.7.10"}
 export PYTHON_VERSION=${2:-"3.10"}
 
 if [[ $(arch) == "x86_64" ]]; then

--- a/packages/postgresml/DEBIAN/control
+++ b/packages/postgresml/DEBIAN/control
@@ -3,7 +3,7 @@ Version: ${PACKAGE_VERSION}
 Section: database
 Priority: optional
 Architecture: all
-Depends: postgresml-python (>= 2.7.4), postgresql-pgml-${PGVERSION} (>= ${PACKAGE_VERSION})
+Depends: postgresml-python (>= 2.7.10), postgresql-pgml-${PGVERSION} (>= ${PACKAGE_VERSION})
 Maintainer: PostgresML <team@postgresml.org>
 Homepage: https://postgresml.org
 Description: PostgresML - Generative AI and Simple ML inside PostgreSQL

--- a/packages/postgresml/build.sh
+++ b/packages/postgresml/build.sh
@@ -3,7 +3,7 @@ set -e
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-export PACKAGE_VERSION=${1:-"2.7.4"}
+export PACKAGE_VERSION=${1:-"2.7.10"}
 export PGVERSION=${2:-"14"}
 
 deb_dir="/tmp/postgresml/deb-build"

--- a/pgml-extension/Cargo.lock
+++ b/pgml-extension/Cargo.lock
@@ -1840,7 +1840,7 @@ dependencies = [
 
 [[package]]
 name = "pgml"
-version = "2.7.9"
+version = "2.7.10"
 dependencies = [
  "anyhow",
  "blas",

--- a/pgml-extension/Cargo.toml
+++ b/pgml-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgml"
-version = "2.7.9"
+version = "2.7.10"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
Release 2.7.10 which updates Python dependencies.

Steps for releasing to production:
1. Tag the release in Github.
2. Build `postgresml-python` package using this Github action: https://github.com/postgresml/postgresml/actions/workflows/ubuntu-postgresml-python-package.yaml
3. Build everything else using this Github action: https://github.com/postgresml/postgresml/actions/workflows/ubuntu-packages-and-docker-image.yml