### PR TITLE
fix rotation of guides text on mobile

### DIFF
--- a/pgml-dashboard/static/css/scss/components/_navs.scss
+++ b/pgml-dashboard/static/css/scss/components/_navs.scss
@@ -149,7 +149,9 @@
         }
     }
     [aria-expanded=false] {
-        transform: rotate(-90deg);
+        span.material-symbols-outlined {
+            transform: rotate(-90deg);
+        }
     }
     @include media-breakpoint-down(xxl) {
         border-radius: 0px;


### PR DESCRIPTION
8788c2b3667ab3f83335e511a82a1d7001e8abec broke guide text orientation on mobile. 
<img width="441" alt="Screenshot 2023-10-19 at 11 52 01 AM" src="https://github.com/postgresml/postgresml/assets/39170265/64bde0e2-17a3-4637-8237-579098c41e45">
