### PR TITLE
Revert "Update to pgrx 0.11.0 & Postgres 16"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           curl https://sh.rustup.rs -sSf | sh -s -- -y
           source ~/.cargo/env
-          cargo install cargo-pgrx --version "0.11.0" --locked
+          cargo install cargo-pgrx --version "0.10.0" --locked
 
           if [[ ! -d ~/.pgrx ]]; then
             cargo pgrx init

--- a/.github/workflows/ubuntu-packages-and-docker-image.yml
+++ b/.github/workflows/ubuntu-packages-and-docker-image.yml
@@ -72,16 +72,16 @@ jobs:
           libpq-dev \
           libclang-dev \
           wget \
-          postgresql-16 \
           postgresql-15 \
           postgresql-14 \
           postgresql-13 \
           postgresql-12 \
-          postgresql-server-dev-16 \
+          postgresql-11 \
           postgresql-server-dev-15 \
           postgresql-server-dev-14 \
           postgresql-server-dev-13 \
           postgresql-server-dev-12 \
+          postgresql-server-dev-11 \
           lsb-release \
           python3.10 \
           python3-pip \
@@ -98,7 +98,7 @@ jobs:
       with:
         working-directory: pgml-extension
         command: install
-        args: cargo-pgrx --version "0.11.0" --locked
+        args: cargo-pgrx --version "0.10.0" --locked
     - name: pgrx init
       uses: postgresml/gh-actions-cargo@master
       with:
@@ -135,12 +135,6 @@ jobs:
         working-directory: pgml-extension
         command: pgrx
         args: package --pg-config /usr/lib/postgresql/15/bin/pg_config
-     name: Build Postgres 16
-      uses: postgresml/gh-actions-cargo@master
-      with:
-        working-directory: pgml-extension
-        command: pgrx
-        args: package --pg-config /usr/lib/postgresql/16/bin/pg_config
     - name: Build debs
       env:
         AWS_ACCESS_KEY_ID: ${{ vars.AWS_ACCESS_KEY_ID }}

--- a/pgml-dashboard/content/docs/guides/setup/developers.md
+++ b/pgml-dashboard/content/docs/guides/setup/developers.md
@@ -70,7 +70,7 @@ Once there, you can initialize `pgrx` and get going:
 
 #### Pgrx command line and environments
 ```commandline
-cargo install cargo-pgrx --version "0.11.0" --locked && \
+cargo install cargo-pgrx --version "0.10.0" --locked && \
 cargo pgrx init # This will take a few minutes
 ```
 

--- a/pgml-dashboard/content/docs/guides/setup/v2/installation.md
+++ b/pgml-dashboard/content/docs/guides/setup/v2/installation.md
@@ -36,7 +36,7 @@ brew bundle
 PostgresML is written in Rust, so you'll need to install the latest compiler from [rust-lang.org](https://rust-lang.org). Additionally, we use the Rust PostgreSQL extension framework `pgrx`, which requires some initialization steps:
 
 ```bash
-cargo install cargo-pgrx --version 0.11.0 && \
+cargo install cargo-pgrx --version 0.10.0 && \
 cargo pgrx init
 ```
 
@@ -294,7 +294,7 @@ We use the `pgrx` Postgres Rust extension framework, which comes with its own in
 
 ```bash
 cd pgml-extension && \
-cargo install cargo-pgrx --version 0.11.0 && \
+cargo install cargo-pgrx --version 0.10.0 && \
 cargo pgrx init
 ```
 

--- a/pgml-docs/docs/guides/deploying-postgresml/self-hosting/building-from-source.md
+++ b/pgml-docs/docs/guides/deploying-postgresml/self-hosting/building-from-source.md
@@ -40,12 +40,12 @@ For a typical deployment in production, you would need to compile and install th
 
 #### Install pgrx
 
-`pgrx` is open source and available from crates.io. We are currently using the `0.11.0` version. It's important that your `pgrx` version matches what we're using, since there are some hard dependencies between our code and `pgrx`.
+`pgrx` is open source and available from crates.io. We are currently using the `0.10.0` version. It's important that your `pgrx` version matches what we're using, since there are some hard dependencies between our code and `pgrx`.
 
 To install `pgrx`, simply run:
 
 ```
-cargo install cargo-pgrx --version "0.11.0"
+cargo install cargo-pgrx --version "0.10.0"
 ```
 
 Before using `pgrx`, it needs to be initialized against the installed version of PostgreSQL. In this example, we'll be using the Ubuntu 22.04 default PostgreSQL 14 installation:

--- a/pgml-extension/Cargo.lock
+++ b/pgml-extension/Cargo.lock
@@ -251,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.68.1"
+version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
  "bitflags 2.4.0",
  "cexpr 0.6.0",
@@ -366,9 +366,9 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cargo_toml"
-version = "0.16.3"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3f9629bc6c4388ea699781dc988c2b99766d7679b151c81990b4fa1208fafd3"
+checksum = "599aa35200ffff8f04c1925aa1acc92fa2e08874379ef42e210a80e527e60838"
 dependencies = [
  "serde",
  "toml",
@@ -794,18 +794,18 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "enum-map"
-version = "2.6.3"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c188012f8542dee7b3996e44dd89461d64aa471b0a7c71a1ae2f595d259e96e5"
+checksum = "4e10d4d903e79b6181943defcdc36f61f8f608e5892eca719fb0677799d3f8fe"
 dependencies = [
  "enum-map-derive",
 ]
 
 [[package]]
 name = "enum-map-derive"
-version = "0.14.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d0b288e3bb1d861c4403c1774a6f7a798781dfc519b3647df2a3dd4ae95f25"
+checksum = "ccb14d927583dd5c2eac0f2cf264fc4762aefe1ae14c47a8a20fc1939d3a5fc0"
 dependencies = [
  "proc-macro2",
  "quote 1.0.33",
@@ -1244,9 +1244,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libloading"
@@ -1876,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.11.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd3c4b36fbe84329b86c83bfd33b9514a50606f00074f47085f99062a7dd8c9c"
+checksum = "eb7ee7e7abe8a74124732d05fdbccd11179b4778c08736995fdfc8ca9d2e9c24"
 dependencies = [
  "atomic-traits",
  "bitflags 2.4.0",
@@ -1901,9 +1901,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.11.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6a41e021321a814fac1aa27bd4266208b4507709ecbc28fc99693adfbd0c41"
+checksum = "26c6d5a93b4c6ceb3735605205267a002584fd3d7fa87eed3133cba6c74f7431"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1913,9 +1913,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.11.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da1e26800e747d501b8d8bb8aeee4530a07d93a39c3fb2c4229a8feff213b2"
+checksum = "14a7885744ba92cd19ad87f2bf195352a9533cd2bb10a1ebbeef7ef9d65126aa"
 dependencies = [
  "cargo_toml",
  "dirs 5.0.1",
@@ -1931,11 +1931,11 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.11.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9032b517525ec71579cc68e92905b5f5f63e892c094834202313c42f2f1a669"
+checksum = "916a552934ebfcf3c56277e682526c8d92264b4c9ba58a7d0a3cddf1e03c6825"
 dependencies = [
- "bindgen 0.68.1",
+ "bindgen 0.66.1",
  "eyre",
  "libc",
  "memoffset 0.9.0",
@@ -1953,9 +1953,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.11.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e4a88203974b887bca8bfdea17ab9936411fb7e84957763dc0124df78d07907"
+checksum = "db087888395237259e1c643777ff619077ace10afa670e5bb4b8d510db63dac0"
 dependencies = [
  "convert_case",
  "eyre",
@@ -1968,9 +1968,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.11.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80deb4310538e6ef14f4cbb30b56eb24b6d7aae66bfd4e516f153987159e65e"
+checksum = "18b3449cbdfdbd25bc24ae7d962fdc0c8eac2a839b5bfee7a295b6c8931b0c0b"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -2077,9 +2077,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -2312,25 +2312,25 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -2341,9 +2341,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "rmp"
@@ -3039,9 +3039,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.2"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
+checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -3060,9 +3060,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.20.2"
+version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
  "indexmap 2.0.0",
  "serde",

--- a/pgml-extension/Cargo.toml
+++ b/pgml-extension/Cargo.toml
@@ -7,20 +7,20 @@ edition = "2021"
 crate-type = ["lib", "cdylib"]
 
 [features]
-default = ["pg16", "python"]
+default = ["pg15", "python"]
+pg11 = ["pgrx/pg11", "pgrx-tests/pg11"]
 pg12 = ["pgrx/pg12", "pgrx-tests/pg12"]
 pg13 = ["pgrx/pg13", "pgrx-tests/pg13"]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
-pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
 use_as_lib = []
 pg_test = []
 python = ["pyo3"]
 cuda = ["xgboost/cuda", "lightgbm/cuda"]
 
 [dependencies]
-pgrx = "=0.11.0"
-pgrx-pg-sys = "=0.11.0"
+pgrx = "=0.10.0"
+pgrx-pg-sys = "=0.10.0"
 xgboost = { git = "https://github.com/postgresml/rust-xgboost.git", branch = "master" }
 once_cell = { version = "1", features = ["parking_lot"] }
 rand = "0.8"
@@ -51,7 +51,7 @@ flate2 = "1.0"
 csv = "1.2"
 
 [dev-dependencies]
-pgrx-tests = "=0.11.0"
+pgrx-tests = "=0.10.0"
 
 [build-dependencies]
 vergen = { version = "8", features = ["build", "git", "gitcl"] }


### PR DESCRIPTION
Reverts postgresml/postgresml#1099

This conflicts with postgresml-python fix. Reverting temporarily until I can release that package first.