### PR TITLE
Interactable ToC

### DIFF
--- a/pgml-dashboard/src/templates/docs.rs
+++ b/pgml-dashboard/src/templates/docs.rs
@@ -1,5 +1,6 @@
 //! Documentation and blog templates.
 use sailfish::TemplateOnce;
+use convert_case::Casing;
 
 use crate::utils::markdown::SearchResult;
 
@@ -78,12 +79,10 @@ impl TocLink {
     ///
     /// * `title` - The title of the link.
     ///
-    pub fn new(title: &str, counter: usize) -> TocLink {
-        let id = format!("header-{}", counter);
-
+    pub fn new(title: &str) -> TocLink {
         TocLink {
             title: title.to_string(),
-            id,
+            id: title.to_case(convert_case::Case::Kebab),
             level: 0,
         }
     }

--- a/pgml-dashboard/static/css/scss/base/_base.scss
+++ b/pgml-dashboard/static/css/scss/base/_base.scss
@@ -43,11 +43,22 @@ pre {
 
 // links
 a {
-    text-decoration: none; 
+    text-decoration: none;
 
     &:not(.btn, .nav .nav-link, .breadcrumb-item a, .list-group-item, .a-reset, .navbar .nav-link, .navbar .navbar-brand, .menu-item a) {
         color: var(--bs-link-color);
         background-color: transparent;
+    }
+
+    &h1, h2, h3, h4, h5, h6 {
+        &:hover {
+            &:before {
+                content: '#';
+                margin-left: -1em;
+                position: absolute;
+            }
+        }
+        scroll-margin-top: 108px;
     }
 }
 

--- a/pgml-dashboard/static/js/docs-toc.js
+++ b/pgml-dashboard/static/js/docs-toc.js
@@ -4,15 +4,27 @@ import {
 
 export default class extends Controller {
   connect() {
-    this.scrollSpyAppend();
-  }
-
-  scrollSpyAppend() {
     const spy = new bootstrap.ScrollSpy(document.body, {
       target: '#toc-nav',
       smoothScroll: true,
       rootMargin: '-10% 0% -50% 0%',
       threshold: [1],
-    })
+    });
+    document.body.addEventListener('activate.bs.scrollspy', function(e) {
+
+    });
+  }
+
+  clicked(e) {
+    console.log('clicked', this, e);
+    let href = e.target.attributes.href.nodeValue;
+    if (href) {
+      if (href.startsWith("#")) {
+        let hash = href.slice(1);
+        if (window.location.hash != hash) {
+          window.location.hash = hash;
+        }
+      }
+    }
   }
 }

--- a/pgml-dashboard/static/js/docs-toc.js
+++ b/pgml-dashboard/static/js/docs-toc.js
@@ -10,13 +10,9 @@ export default class extends Controller {
       rootMargin: '-10% 0% -50% 0%',
       threshold: [1],
     });
-    document.body.addEventListener('activate.bs.scrollspy', function(e) {
-
-    });
   }
 
   clicked(e) {
-    console.log('clicked', this, e);
     let href = e.target.attributes.href.nodeValue;
     if (href) {
       if (href.startsWith("#")) {

--- a/pgml-dashboard/templates/components/toc.html
+++ b/pgml-dashboard/templates/components/toc.html
@@ -1,5 +1,5 @@
 <!-- TODO: Determine if this is needed, remove if it isnt.  Also look 
- at docs.html, which impliments this. -->
+ at docs.html, which implements this. -->
 <% if !links.is_empty() { %>
 <h6 class="mb-2 pb-2 d-none d-xxl-block">Table of Contents</h6>
 <a class="px-0 my-1 d-flex justify-content-between align-items-center d-xxl-none text-white" role="button" data-bs-toggle="collapse" href="#toc-nav" aria-expanded="false" aria-congrols="tox-nav">
@@ -9,7 +9,7 @@
 <div id="toc-nav" class="d-xxl-flex pt-2 flex-column collapse border-top" aria-orientation="vertical" data-controller="docs-toc">
   <% for link in links.iter() { %>
     <div style="padding-left: <%= link.level as f32 * 0.7 - 1.4 %>rem;">
-      <a  class="nav-link px-0 text-break" href="#<%= link.id %>" role="button" data-action="docs-toc#scrollSpyAppend" >
+      <a  class="nav-link px-0 text-break" href="#<%= link.id %>" role="button" data-action="docs-toc#clicked" >
         <%= link.title %>
       </a>
     </div>

--- a/pgml-dashboard/templates/layout/nav/toc.html
+++ b/pgml-dashboard/templates/layout/nav/toc.html
@@ -10,7 +10,7 @@
         <div id="toc-nav" class="d-xxl-flex pt-2 flex-column collapse border-top" aria-orientation="vertical" data-controller="docs-toc">
           <% for link in toc_links.iter() { %>
             <div style="padding-left: <%= link.level as f32 * 0.7 - 1.4 %>rem;">
-              <a  class="nav-link px-0 text-break" href="#<%= link.id %>" role="button" data-action="docs-toc#scrollSpyAppend" >
+              <a class="nav-link px-0 text-break" href="#<%= link.id %>" role="button" data-action="docs-toc#clicked" >
                 <%= link.title %>
               </a>
             </div>


### PR DESCRIPTION
Various fixes for the interactivity of the ToC

- Use human readable anchors that refer to the content for stable external links and seo
- Add a visual indicator that headings are clickable (#)
- Update the window.location when the ToC is clicked for increased discoverability
- Fix scrollspy being re-appended every time it activates... recursively adding itself until it's firing exponentially
- Fix deep links to headers being obscured by our sticky nav