### PR TITLE
Add support for Ollama, Palm, Claude-2, Cohere, Replicate Llama2 CodeLlama (100+LLMs) - using LiteLLM

### DIFF
--- a/pgml-apps/pgml-chat/pgml_chat/main.py
+++ b/pgml-apps/pgml-chat/pgml_chat/main.py
@@ -10,6 +10,7 @@ import glob
 import argparse
 from time import time
 import openai
+import litellm
 import signal
 
 import ast
@@ -120,9 +121,9 @@ async def upsert_documents(folder: str) -> int:
 async def generate_response(
     messages, openai_api_key, temperature=0.7, max_tokens=256, top_p=0.9
 ):
-    openai.api_key = openai_api_key
+    litellm.api_key = openai_api_key
     log.debug("Generating response from OpenAI API: " + str(messages))
-    response = openai.ChatCompletion.create(
+    response = litellm.completion(
         model="gpt-3.5-turbo",
         messages=messages,
         temperature=temperature,

--- a/pgml-apps/pgml-chat/pyproject.toml
+++ b/pgml-apps/pgml-chat/pyproject.toml
@@ -10,6 +10,7 @@ packages = [{include = "pgml_chat"}]
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
 openai = "^0.27.8"
+litellm = "^0.11.1"
 rich = "^13.4.2"
 pgml = "^0.9.0"
 python-dotenv = "^1.0.0"


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM is a lightweight package to simplify LLM API calls - use any llm as a drop in replacement for gpt-3.5-turbo. 


Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion(model="command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```