### PR TITLE
Mutable SQL commands should be used with Spi::update().

### DIFF
--- a/pgml-extension/src/orm/dataset.rs
+++ b/pgml-extension/src/orm/dataset.rs
@@ -95,7 +95,7 @@ impl Display for TextDataset {
 fn drop_table_if_exists(table_name: &str) {
     // Avoid the existence for DROP TABLE IF EXISTS warning by checking the schema for the table first
     let table_count = Spi::get_one_with_args::<i64>("SELECT COUNT(*) FROM information_schema.tables WHERE table_name = $1 AND table_schema = 'pgml'", vec![
-        (PgBuiltInOids::TEXTOID.oid(), table_name.clone().into_datum())
+        (PgBuiltInOids::TEXTOID.oid(), table_name.into_datum())
     ]).unwrap().unwrap();
     if table_count == 1 {
         Spi::run(&format!(r#"DROP TABLE pgml.{table_name} CASCADE"#)).unwrap();

--- a/pgml-extension/src/orm/model.rs
+++ b/pgml-extension/src/orm/model.rs
@@ -96,8 +96,8 @@ impl Model {
         let dataset = snapshot.tabular_dataset();
         let status = Status::in_progress;
         // Create the model record.
-        Spi::connect(|client| {
-            let result = client.select("
+        Spi::connect(|mut client| {
+            let result = client.update("
           INSERT INTO pgml.models (project_id, snapshot_id, algorithm, runtime, hyperparams, status, search, search_params, search_args, num_features)
           VALUES ($1, $2, cast($3 AS pgml.algorithm), cast($4 AS pgml.runtime), $5, cast($6 as pgml.status), $7, $8, $9, $10)
           RETURNING id, project_id, snapshot_id, algorithm, runtime, hyperparams, status, metrics, search, search_params, search_args, created_at, updated_at;",
@@ -168,8 +168,8 @@ impl Model {
         let dataset = snapshot.text_dataset();
 
         // Create the model record.
-        Spi::connect(|client| {
-            let result = client.select("
+        Spi::connect(|mut client| {
+            let result = client.update("
           INSERT INTO pgml.models (project_id, snapshot_id, algorithm, runtime, hyperparams, status, search, search_params, search_args, num_features)
           VALUES ($1, $2, cast($3 AS pgml.algorithm), cast($4 AS pgml.runtime), $5, cast($6 as pgml.status), $7, $8, $9, $10)
           RETURNING id, project_id, snapshot_id, algorithm, runtime::TEXT, hyperparams, status, metrics, search, search_params, search_args, created_at, updated_at;",


### PR DESCRIPTION
Commands like 'INSERT', 'CREATE TABLE' are modifying database objects. They should be used with 'Spi::update()'[^1][^2].

Besides, one of the unnecessary calling of '.clone()' is removed.

[^1]: https://www.postgresql.org/docs/current/spi-spi-execute.html
[^2]: https://github.com/pgcentralfoundation/pgrx/blob/64fbc2e2efb06212046082ffcde2e794ccb4d48a/pgrx/src/spi/client.rs#L60

Co-Authored-By: Chen Mulong <chenmulong@gmail.com>