### PR TITLE
Fix ubuntu package and docker image deployment workflow

### DIFF
--- a/.github/workflows/ubuntu-packages-and-docker-image.yml
+++ b/.github/workflows/ubuntu-packages-and-docker-image.yml
@@ -104,7 +104,7 @@ jobs:
       with:
         working-directory: pgml-extension
         command: pgrx
-        args: --pg12=/usr/lib/postgresql/12/bin/pg_config --pg13=/usr/lib/postgresql/13/bin/pg_config --pg14=/usr/lib/postgresql/14/bin/pg_config --pg15=/usr/lib/postgresql/15/bin/pg_config --pg16=/usr/lib/postgresql/16/bin/pg_config
+        args: init --pg12=/usr/lib/postgresql/12/bin/pg_config --pg13=/usr/lib/postgresql/13/bin/pg_config --pg14=/usr/lib/postgresql/14/bin/pg_config --pg15=/usr/lib/postgresql/15/bin/pg_config --pg16=/usr/lib/postgresql/16/bin/pg_config
     - name: Build Postgres 12
       uses: postgresml/gh-actions-cargo@master
       with:


### PR DESCRIPTION
Hello @levkk @montanalow 

Just saw the [latest ubuntu package and docker image job failing for 2.7.12 release](https://github.com/postgresml/postgresml/actions/runs/6630279778/job/18011370794) and wanted to provide my modest help.