### PR TITLE
Added pyarrow==11.0.0 to requirements to solve postgres segfault

### DIFF
--- a/pgml-extension/requirements.txt
+++ b/pgml-extension/requirements.txt
@@ -29,3 +29,4 @@ pynvml==11.5.0
 transformers-stream-generator==0.0.4
 optimum==1.13.2
 peft==0.6.2
+pyarrow==11.0.0


### PR DESCRIPTION
Added pyarrow==11.0.0 to requirements to solve issue where postgres would segfault after a client session which used pgml command closes. The issue can be identified in postgres log files with the line 'arrow::fs::FinalizeS3 was not called even though S3 was initialized.  This could lead to a segmentation fault at exit'

Same issue as shown here: https://github.com/AlUlkesh/stable-diffusion-webui-images-browser/issues/216