### PR TITLE
Added embed2 which returns a table structure

### DIFF
--- a/pgml-extension/requirements.txt
+++ b/pgml-extension/requirements.txt
@@ -29,3 +29,4 @@ pynvml==11.5.0
 transformers-stream-generator==0.0.4
 optimum==1.13.2
 peft==0.6.2
+pyarrow==11.0.0

--- a/pgml-extension/src/api.rs
+++ b/pgml-extension/src/api.rs
@@ -558,6 +558,26 @@ pub fn embed_batch(
     }
 }
 
+#[cfg(all(feature = "python", not(feature = "use_as_lib")))]
+#[pg_extern(immutable, parallel_safe, name = "embed2")]
+pub fn embed_batch2<'a>(
+    transformer: &str,
+    inputs: Vec<&'a str>,
+    kwargs: default!(JsonB, "'{}'"),
+) -> TableIterator<'a, (name!(text, String), name!(embedding, Vec<f32>))> {
+    let rows = match crate::bindings::transformers::embed(transformer, inputs.clone(), &kwargs.0) {
+        Ok(rows) => rows,
+        Err(e) => {
+            error!("{e}");
+        }
+    };
+    TableIterator::new(
+        inputs.into_iter().zip(rows.into_iter()).map(|(text, embedding)| {
+            (text.to_string(), embedding)
+        }),
+    )
+}
+
 /// Clears the GPU cache.
 ///
 /// # Arguments


### PR DESCRIPTION
The proposed change added new wrapper for pgml.embed, this will instead of return a single row, return a table structure which is very useful for batch processing strings.

Example usage is
```sql
select * from 
    pgml.embed2('all-MiniLM-L6-v2', (select array_agg(phrase) from (select * from phrases limit 10)));
```
To import the function is as follows:
```sql
CREATE OR REPLACE FUNCTION pgml."embed2"(
    transformer TEXT,
    inputs TEXT[],
    kwargs JSONB DEFAULT '{}'
) RETURNS TABLE (text TEXT, embedding real[]) 
    LANGUAGE c IMMUTABLE STRICT PARALLEL SAFE AS 'MODULE_PATHNAME', 'embed_batch2_wrapper';
```