### PR TITLE
Fix Gitbook relative links

### DIFF
--- a/pgml-cms/careers/full-stack-engineer.md
+++ b/pgml-cms/careers/full-stack-engineer.md
@@ -35,5 +35,3 @@ We take care of our team and care about your well being.
 ### Employment Eligibility
 
 You must be eligible to work in the United States.
-
-\

--- a/pgml-cms/careers/machine-learning-engineer.md
+++ b/pgml-cms/careers/machine-learning-engineer.md
@@ -35,5 +35,3 @@ We take care of our team and care about your well being.
 ### Employment Eligibility
 
 You must be eligible to work in the United States.
-
-\

--- a/pgml-cms/careers/product-manager.md
+++ b/pgml-cms/careers/product-manager.md
@@ -36,4 +36,3 @@ We take care of our team and care about your well being.
 
 You must be eligible to work in the United States.
 
-\

--- a/pgml-dashboard/src/components/navigation/tabs/mod.rs
+++ b/pgml-dashboard/src/components/navigation/tabs/mod.rs
@@ -6,6 +6,5 @@ pub mod tab;
 pub use tab::Tab;
 
 // src/components/navigation/tabs/tabs
-#[allow(clippy::module_inception)]
 pub mod tabs;
 pub use tabs::Tabs;

--- a/pgml-dashboard/src/utils/markdown.rs
+++ b/pgml-dashboard/src/utils/markdown.rs
@@ -917,6 +917,20 @@ pub fn mkdocs<'a>(root: &'a AstNode<'a>, arena: &'a Arena<AstNode<'a>>) -> anyho
 
     iter_nodes(root, &mut |node| {
         match &mut node.data.borrow_mut().value {
+            &mut NodeValue::Link(ref mut link) => {
+                let path = Path::new(link.url.as_str());
+
+                if path.is_relative() {
+                    if link.url.ends_with(".md") {
+                        for _ in 0..".md".len() {
+                            link.url.pop();
+                        }
+                    }
+                }
+
+                Ok(true)
+            }
+
             &mut NodeValue::Text(ref mut text) => {
                 if text.starts_with("=== \"") {
                     let mut parent = {


### PR DESCRIPTION
1. Fix Gitbook relative links. They add `.md` to some of them, which gives us a 404 in the dashboard naturally.
2. Remove trailing slash from some careers pages.