### PR TITLE
Dont crash watch on error

### DIFF
--- a/packages/cargo-pgml-components/Cargo.lock
+++ b/packages/cargo-pgml-components/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgml-components"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/packages/cargo-pgml-components/Cargo.toml
+++ b/packages/cargo-pgml-components/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pgml-components"
-version = "0.1.23"
+version = "0.1.24"
 edition = "2021"
 authors = ["PostgresML <team@postgresml.org>"]
 license = "MIT"

--- a/packages/cargo-pgml-components/src/frontend/tools.rs
+++ b/packages/cargo-pgml-components/src/frontend/tools.rs
@@ -132,6 +132,8 @@ pub fn debug() {
 }
 
 pub fn watch() {
+    rebuild();
+
     let mut debouncer = unwrap_or_exit!(new_debouncer(
         Duration::from_secs(1),
         None,
@@ -156,9 +158,7 @@ pub fn watch() {
                     }
 
                     if detected {
-                        print("changes detected, rebuilding...");
                         rebuild();
-                        info("done");
                     }
                 }
 
@@ -211,7 +211,12 @@ pub fn lint(check: bool) {
 }
 
 fn rebuild() {
-    unwrap_or_exit!(execute_command(
-        Command::new("cargo").arg("pgml-components").arg("bundle")
-    ));
+    print("changes detected, rebuilding...");
+    match execute_command(Command::new("cargo").arg("pgml-components").arg("bundle")) {
+        Ok(_) => info("ok"),
+        Err(err) => {
+            error("error");
+            error!("{}", err);
+        }
+    }
 }


### PR DESCRIPTION
1. Don't crash `pgml-components watch` on error.
2. Rebuild before watching for new changes, so `watch` actually builds the bundle on start.