### PR TITLE
Dan docs 2

### DIFF
--- a/pgml-dashboard/src/api/cms.rs
+++ b/pgml-dashboard/src/api/cms.rs
@@ -40,10 +40,7 @@ pub struct Document {
 
 impl Document {
     pub async fn from_path(path: &PathBuf) -> anyhow::Result<Document, std::io::Error> {
-        let contents = match tokio::fs::read_to_string(&path).await {
-            Ok(contents) => contents,
-            Err(_) => String::from("<h3>Failed to find your requested document!</h3>"),
-        };
+        let contents = tokio::fs::read_to_string(&path).await?;
 
         let parts = contents.split("---").collect::<Vec<&str>>();
 


### PR DESCRIPTION
- Lets do this rather than catch since catch can't take context.  This provides a smooth experience but keeps the SE indexing clean. 