### PR TITLE
[docs] Update local installation guide

### DIFF
--- a/pgml-cms/docs/resources/developer-docs/contributing.md
+++ b/pgml-cms/docs/resources/developer-docs/contributing.md
@@ -67,7 +67,7 @@ Once there, you can initialize `pgrx` and get going:
 #### Pgrx command line and environments
 
 ```commandline
-cargo install cargo-pgrx --version "0.9.8" --locked && \
+cargo install cargo-pgrx --version "0.11.2" --locked && \
 cargo pgrx init # This will take a few minutes
 ```
 

--- a/pgml-cms/docs/resources/developer-docs/installation.md
+++ b/pgml-cms/docs/resources/developer-docs/installation.md
@@ -63,8 +63,7 @@ To install the necessary Python packages into a virtual environment, use the `vi
 ```bash
 virtualenv pgml-venv && \
 source pgml-venv/bin/activate && \
-pip install -r requirements.txt && \
-pip install -r requirements-xformers.txt --no-dependencies
+pip install -r requirements.txt
 ```
 {% endtab %}
 

--- a/pgml-cms/docs/resources/developer-docs/installation.md
+++ b/pgml-cms/docs/resources/developer-docs/installation.md
@@ -145,7 +145,7 @@ pgml_test=# SELECT pgml.version();
 We like and use pgvector a lot, as documented in our blog posts and examples, to store and search embeddings. You can install pgvector from source pretty easily:
 
 ```bash
-git clone --branch v0.4.4 https://github.com/pgvector/pgvector && \
+git clone --branch v0.5.0 https://github.com/pgvector/pgvector && \
 cd pgvector && \
 echo "trusted = true" >> vector.control && \
 make && \

--- a/pgml-cms/docs/resources/developer-docs/installation.md
+++ b/pgml-cms/docs/resources/developer-docs/installation.md
@@ -36,7 +36,7 @@ brew bundle
 PostgresML is written in Rust, so you'll need to install the latest compiler from [rust-lang.org](https://rust-lang.org). Additionally, we use the Rust PostgreSQL extension framework `pgrx`, which requires some initialization steps:
 
 ```bash
-cargo install cargo-pgrx --version 0.9.8 && \
+cargo install cargo-pgrx --version 0.11.2 && \
 cargo pgrx init
 ```
 
@@ -288,7 +288,7 @@ We use the `pgrx` Postgres Rust extension framework, which comes with its own in
 
 ```bash
 cd pgml-extension && \
-cargo install cargo-pgrx --version 0.9.8 && \
+cargo install cargo-pgrx --version 0.11.2 && \
 cargo pgrx init
 ```
 


### PR DESCRIPTION
This PR updates the local installation docs:

* Updates the version of cargo-pgrx to 0.11.2 to match the rest of the project
* Updates the version of pgvector to use
* Removes a reference to `requirements-xformers.txt` file that doesn't exist anymore
