### PR TITLE
handle model deploy when no metrics to compare

### DIFF
--- a/pgml-extension/src/api.rs
+++ b/pgml-extension/src/api.rs
@@ -284,7 +284,7 @@ fn train_joint(
                     ) {
                         if project.task.value_is_better(deployed_metric_value, new_metric_value) {
                             warning!(
-                                "New model's {} is not better than old model: {} is not better than {}",
+                                "New model's {} is not better than current model. New: {}, Current {}",
                                 &project.task.default_target_metric(),
                                 new_metric_value,
                                 deployed_metric_value

--- a/pgml-extension/src/api.rs
+++ b/pgml-extension/src/api.rs
@@ -266,7 +266,7 @@ fn train_joint(
     let mut deploy = true;
 
     match automatic_deploy {
-        // Deploy only if metrics are better than previous model.
+        // Deploy only if metrics are better than previous model, or if its the first model
         Some(true) | None => {
             if let Ok(Some(deployed_metrics)) = deployed_metrics {
                 if let Some(deployed_metrics_obj) = deployed_metrics.0.as_object() {
@@ -297,12 +297,9 @@ fn train_joint(
                         deploy = false;
                     }
                 } else {
-                    warning!("Failed to parse deployed model metrics. Ensure train/test split results in both positive and negative label records.");
+                    warning!("Failed to parse deployed model metrics. Check data types of model metadata on pgml.models.metrics");
                     deploy = false;
                 }
-            } else {
-                warning!("Failed to obtain currently deployed model metrics. Check if the deployed model metrics are available and correctly formatted.");
-                deploy = false;
             }
         }
         Some(false) => {


### PR DESCRIPTION
The autodeploy feature deploys the newly trained model only if the `f1` score is higher than the model that is currently deployed. However, there can be cases where we aren't able to compute the `f1` score, such as when the test set only contains positive labels (results in divide by zero).  This can happen if the training data is sorted by labels in Postgres and `test_sampling => 'first'`, or if its just a horribly unbalanced training set and some bad luck with `test_sampling => 'random'`.

In either case, there's legitimate reasons that the f1 score does not exist. So, rather than crash we can do two things;
1. not supersede the currently deployed -- if we cant compute the metrics, I think its safe to assume its not better than the currently deployed model
2. give user a meaningful warning log so they can troubleshoot