### PR TITLE
update deeplink

### DIFF
--- a/pgml-dashboard/src/api/cms.rs
+++ b/pgml-dashboard/src/api/cms.rs
@@ -116,19 +116,15 @@ pub struct Document {
 impl Document {
     pub async fn from_path(path: &PathBuf) -> anyhow::Result<Document, std::io::Error> {
         let doc_type = match path.strip_prefix(config::cms_dir()) {
-            Ok(path) => {
-                match path.into_iter().next() {
-                    Some(dir) => {
-                        match &PathBuf::from(dir).display().to_string()[..] {
-                            "blog" => Some(DocType::Blog),
-                            "docs" => Some(DocType::Docs),
-                            "careers" => Some(DocType::Careers),
-                            _ => None
-                        }
-                    },
-                    _ => None
-                } 
-            }, 
+            Ok(path) => match path.into_iter().next() {
+                Some(dir) => match &PathBuf::from(dir).display().to_string()[..] {
+                    "blog" => Some(DocType::Blog),
+                    "docs" => Some(DocType::Docs),
+                    "careers" => Some(DocType::Careers),
+                    _ => None,
+                },
+                _ => None,
+            },
             _ => None,
         };
 
@@ -155,7 +151,11 @@ impl Document {
             (None, contents)
         };
 
-        let default_image_path = BLOG.asset_url_root.join("blog_image_placeholder.png").display().to_string();
+        let default_image_path = BLOG
+            .asset_url_root
+            .join("blog_image_placeholder.png")
+            .display()
+            .to_string();
 
         // parse meta section
         let (description, image, featured, tags) = match meta {
@@ -171,16 +171,14 @@ impl Document {
                     Some(default_image_path.clone())
                 } else {
                     match PathBuf::from_str(meta["image"].as_str().unwrap()) {
-                        Ok(image_path) => {
-                            match image_path.file_name() {
-                                Some(file_name) => {
-                                    let file = PathBuf::from(file_name).display().to_string();
-                                    Some(BLOG.asset_url_root.join(file).display().to_string())
-                                }, 
-                                _ => Some(default_image_path.clone())
+                        Ok(image_path) => match image_path.file_name() {
+                            Some(file_name) => {
+                                let file = PathBuf::from(file_name).display().to_string();
+                                Some(BLOG.asset_url_root.join(file).display().to_string())
                             }
+                            _ => Some(default_image_path.clone()),
                         },
-                        _ => Some(default_image_path.clone())
+                        _ => Some(default_image_path.clone()),
                     }
                 };
 
@@ -202,12 +200,7 @@ impl Document {
 
                 (description, image, featured, tags)
             }
-            None => (
-                None,
-                Some(default_image_path.clone()),
-                false,
-                Vec::new(),
-            ),
+            None => (None, Some(default_image_path.clone()), false, Vec::new()),
         };
 
         let thumbnail = match &image {
@@ -287,7 +280,7 @@ pub struct Collection {
     /// A list of old paths to new paths in this collection
     redirects: HashMap<&'static str, &'static str>,
     /// Url to assets for this collection
-    pub asset_url_root: PathBuf
+    pub asset_url_root: PathBuf,
 }
 
 impl Collection {
@@ -455,7 +448,7 @@ impl Collection {
         if path.has_root() {
             path = path.strip_prefix("/").unwrap().to_owned();
         }
-        
+
         let mut path_v = path.components().collect::<Vec<_>>();
         path_v.remove(0);
 
@@ -870,7 +863,7 @@ This is the end of the markdown
         )
     }
 
-    // Test we can parse doc meta with out issue. 
+    // Test we can parse doc meta with out issue.
     #[sqlx::test]
     async fn docs_meta_parse() {
         let collection = &crate::api::cms::DOCS;
@@ -883,7 +876,7 @@ This is the end of the markdown
         }
     }
 
-    // Test we can parse blog meta with out issue. 
+    // Test we can parse blog meta with out issue.
     #[sqlx::test]
     async fn blog_meta_parse() {
         let collection = &crate::api::cms::BLOG;
@@ -896,7 +889,7 @@ This is the end of the markdown
         }
     }
 
-    // Test we can parse career meta with out issue. 
+    // Test we can parse career meta with out issue.
     #[sqlx::test]
     async fn career_meta_parse() {
         let collection = &crate::api::cms::CAREERS;

--- a/pgml-dashboard/src/components/pages/blog/landing_page/mod.rs
+++ b/pgml-dashboard/src/components/pages/blog/landing_page/mod.rs
@@ -30,9 +30,7 @@ impl LandingPage {
         for url in urls {
             let file = collection.url_to_path(url.as_ref());
 
-            let doc = crate::api::cms::Document::from_path(&file)
-                .await
-                .unwrap();
+            let doc = crate::api::cms::Document::from_path(&file).await.unwrap();
 
             let meta = DocMeta {
                 description: doc.description,

--- a/pgml-dashboard/src/templates/docs.rs
+++ b/pgml-dashboard/src/templates/docs.rs
@@ -1,9 +1,6 @@
 use convert_case;
-use lazy_static::lazy_static;
 use sailfish::TemplateOnce;
 use serde::{Deserialize, Serialize};
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
 
 use crate::utils::markdown::SearchResult;
 
@@ -13,26 +10,6 @@ use crate::utils::markdown::SearchResult;
 pub struct Search {
     pub query: String,
     pub results: Vec<SearchResult>,
-}
-
-lazy_static! {
-    static ref CMS_IDENTIFIER: CmsIdentifier = CmsIdentifier::new();
-}
-
-// Prevent css collisions in cms header ids.
-pub struct CmsIdentifier {
-    pub id: String,
-}
-
-impl CmsIdentifier {
-    pub fn new() -> CmsIdentifier {
-        let mut s = DefaultHasher::new();
-        "cms header".hash(&mut s);
-
-        CmsIdentifier {
-            id: s.finish().to_string(),
-        }
-    }
 }
 
 /// Table of contents link.
@@ -57,14 +34,12 @@ impl TocLink {
 
         // gitbook style id's
         let id = format!(
-            "{}{}-{}",
-            id,
+            "{id}{}",
             if counter > 0 {
                 format!("-{counter}")
             } else {
                 String::new()
-            },
-            CMS_IDENTIFIER.id
+            }
         );
 
         TocLink {
@@ -92,7 +67,7 @@ impl TocLink {
             },
             _ => TocLink {
                 title: link.clone(),
-                id: format!("#{}-{}", link.clone(), CMS_IDENTIFIER.id),
+                id: format!("{}", link.clone()),
                 level: 0,
             },
         }

--- a/pgml-dashboard/src/utils/config.rs
+++ b/pgml-dashboard/src/utils/config.rs
@@ -146,7 +146,11 @@ pub fn asset_url(path: Cow<str>) -> String {
 }
 
 pub fn site_domain() -> String {
-    String::from("https://postgresml.org")
+    if CONFIG.dev_mode {
+        String::from("https://localhost")
+    } else {
+        String::from("https://postgresml.org")
+    }
 }
 
 fn env_is_set(name: &str) -> bool {

--- a/pgml-dashboard/static/js/docs-toc.js
+++ b/pgml-dashboard/static/js/docs-toc.js
@@ -3,19 +3,6 @@ import {
 } from '@hotwired/stimulus';
 
 export default class extends Controller {
-  connect() {
-    this.scrollSpyAppend();
-  }
-
-  scrollSpyAppend() {
-    const spy = new bootstrap.ScrollSpy(document.body, {
-      target: '#toc-nav',
-      smoothScroll: true,
-      rootMargin: '-10% 0% -50% 0%',
-      threshold: [1],
-    })
-  }
-
   setUrlFragment(e) {
     let href = e.target.attributes.href.nodeValue;
     if (href) {


### PR DESCRIPTION
 - Remove hash from header id's, this was too conservative. We don't really us id's for styling anyway.
 - Remove scroll spy.  It is going away anyways and it uses quarySelector. querySelector id matching does not match css id character requirements causing querySelector DOMException: Failed to execute 'querySelector' on 'Element' errors for special character 
 - refine path/URI filtering for stripping .md.  Github uses .md in url we were stripping this causing broken links. 
 - fmt