### PR TITLE
[pgml-components] Add template-only option & remove boilerplate

### DIFF
--- a/packages/cargo-pgml-components/Cargo.lock
+++ b/packages/cargo-pgml-components/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgml-components"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/packages/cargo-pgml-components/Cargo.toml
+++ b/packages/cargo-pgml-components/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pgml-components"
-version = "0.1.24"
+version = "0.1.25"
 edition = "2021"
 authors = ["PostgresML <team@postgresml.org>"]
 license = "MIT"

--- a/packages/cargo-pgml-components/src/frontend/components.rs
+++ b/packages/cargo-pgml-components/src/frontend/components.rs
@@ -86,7 +86,7 @@ impl From<&Path> for Component {
 }
 
 /// Add a new component.
-pub fn add(path: &Path, overwrite: bool) {
+pub fn add(path: &Path, overwrite: bool, template_only: bool) {
     if let Some(_extension) = path.extension() {
         error("component name should not contain an extension");
         exit(1);
@@ -154,17 +154,21 @@ pub fn add(path: &Path, overwrite: bool) {
     unwrap_or_exit!(write_to_file(&html_path, &html));
     info(&format!("written {}", html_path.display()));
 
-    let stimulus_path = path.join(&component.controller_path());
-    unwrap_or_exit!(write_to_file(&stimulus_path, &stimulus));
-    info(&format!("written {}", stimulus_path.display()));
+    if !template_only {
+        let stimulus_path = path.join(&component.controller_path());
+        unwrap_or_exit!(write_to_file(&stimulus_path, &stimulus));
+        info(&format!("written {}", stimulus_path.display()));
+    }
 
     let rust_path = path.join("mod.rs");
     unwrap_or_exit!(write_to_file(&rust_path, &rust));
     info(&format!("written {}", rust_path.display()));
 
-    let scss_path = path.join(&format!("{}.scss", component.name()));
-    unwrap_or_exit!(write_to_file(&scss_path, &scss));
-    info(&format!("written {}", scss_path.display()));
+    if !template_only {
+        let scss_path = path.join(&format!("{}.scss", component.name()));
+        unwrap_or_exit!(write_to_file(&scss_path, &scss));
+        info(&format!("written {}", scss_path.display()));
+    }
 
     update_modules();
 }

--- a/packages/cargo-pgml-components/src/frontend/templates/component.rs.tpl
+++ b/packages/cargo-pgml-components/src/frontend/templates/component.rs.tpl
@@ -3,15 +3,11 @@ use pgml_components::component;
 
 #[derive(TemplateOnce, Default)]
 #[template(path = "<%= component.path() %>/template.html")]
-pub struct <%= component.rust_name() %> {
-    value: String,
-}
+pub struct <%= component.rust_name() %> {}
 
 impl <%= component.rust_name() %> {
     pub fn new() -> <%= component.rust_name() %> {
-        <%= component.rust_name() %> {
-            value: String::from("<%= component.full_path() %>"),
-        }
+        <%= component.rust_name() %> {}
     }
 }
 

--- a/packages/cargo-pgml-components/src/frontend/templates/sass.scss.tpl
+++ b/packages/cargo-pgml-components/src/frontend/templates/sass.scss.tpl
@@ -1,17 +1,3 @@
 div[data-controller="<%= component.controller_name() %>"] {
-    // Used to identify the component in the DOM.
-    // Delete these styles if you don't need them.
-    min-width: 100px;
-    width: 100%;
-    height: 100px;
 
-    background: red;
-
-    display: flex;
-    justify-content: center;
-    align-items: center;
-
-    h3 {
-        color: white;
-    }
 }

--- a/packages/cargo-pgml-components/src/frontend/templates/stimulus.js.tpl
+++ b/packages/cargo-pgml-components/src/frontend/templates/stimulus.js.tpl
@@ -1,11 +1,11 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
-  static targets = []
-  static outlets = []
+  static targets = [];
+  static outlets = [];
 
   initialize() {
-    console.log('Initialized <%= controller_name %>')
+    console.log("Initialized <%= controller_name %>");
   }
 
   connect() {}

--- a/packages/cargo-pgml-components/src/frontend/templates/template.html.tpl
+++ b/packages/cargo-pgml-components/src/frontend/templates/template.html.tpl
@@ -1,5 +1,3 @@
 <div data-controller="<%= component.controller_name() %>">
-  <h3 class="text-center h3">
-    <%%= value %>
-  </h3>
+
 </div>

--- a/packages/cargo-pgml-components/src/main.rs
+++ b/packages/cargo-pgml-components/src/main.rs
@@ -89,7 +89,14 @@ enum Commands {
 #[derive(Subcommand, Debug)]
 enum AddCommands {
     /// Add a new component.
-    Component { name: String },
+    Component {
+        /// Name of the new component.
+        name: String,
+
+        /// Generate only the HTML template. Don't generate SCSS and JavaScript.
+        #[arg(short, long, default_value = "false")]
+        template_only: bool,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -114,9 +121,14 @@ fn main() {
                     lock,
                 } => bundle(config, minify, debug, lock),
                 Commands::Add(command) => match command {
-                    AddCommands::Component { name } => {
-                        crate::frontend::components::add(&Path::new(&name), pgml_commands.overwrite)
-                    }
+                    AddCommands::Component {
+                        name,
+                        template_only,
+                    } => crate::frontend::components::add(
+                        &Path::new(&name),
+                        pgml_commands.overwrite,
+                        template_only,
+                    ),
                 },
                 Commands::LocalDev(command) => match command {
                     LocalDevCommands::Check {} => local_dev::setup(),


### PR DESCRIPTION
### pgml-components

1. Add `--template-only` argument to generate only the Sailfish .html template (and mod.rs). No Stimulus controller/Sass stylesheet are generated. This is a common use-case for components that don't need their own styling but are re-used multiple places.
2. Remove a bunch of boilerplate code from generated components. Make sure the Stimulus controller is prettier-compliant when generated. 