### PR TITLE
Prevent search on every page visit

### DIFF
--- a/pgml-dashboard/templates/components/search_modal.html
+++ b/pgml-dashboard/templates/components/search_modal.html
@@ -8,7 +8,7 @@
         </div>
       </div>
       <div class="modal-body">
-        <turbo-frame id="search-results" src="/search?query=" data-search-target="searchFrame" loading="lazy" data-turbo-permanent>
+        <turbo-frame id="search-results" src="/search?query=" data-search-target="searchFrame" loading="lazy">
         </turbo-frame>
       </div>
     </div>

--- a/pgml-dashboard/templates/components/search_modal.html
+++ b/pgml-dashboard/templates/components/search_modal.html
@@ -8,7 +8,7 @@
         </div>
       </div>
       <div class="modal-body">
-        <turbo-frame id="search-results" src="/search?query=" data-search-target="searchFrame">
+        <turbo-frame id="search-results" src="/search?query=" data-search-target="searchFrame" loading="lazy" data-turbo-permanent>
         </turbo-frame>
       </div>
     </div>


### PR DESCRIPTION
- make search modal  lazy to prevent triggering search on every navigation.  This now calls only when search modal is opened.  We could go further and make it a data-turbo-permanent but this runs into issues with get by id on controller connect.  It fails to find the element by id.  It can be overcome by getting target element on search.  Not really worth the change for now.