### PR TITLE
Embeddings support in the SDK

### DIFF
--- a/pgml-sdks/pgml/Cargo.lock
+++ b/pgml-sdks/pgml/Cargo.lock
@@ -1592,7 +1592,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pgml"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/pgml-sdks/pgml/Cargo.toml
+++ b/pgml-sdks/pgml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgml"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 authors = ["PosgresML <team@postgresml.org>"]
 homepage = "https://postgresml.org/"

--- a/pgml-sdks/pgml/python/tests/requirements.txt
+++ b/pgml-sdks/pgml/python/tests/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-asyncio

--- a/pgml-sdks/pgml/python/tests/test.py
+++ b/pgml-sdks/pgml/python/tests/test.py
@@ -72,6 +72,18 @@ def test_can_create_builtins():
     builtins = pgml.Builtins()
     assert builtins is not None
 
+@pytest.mark.asyncio
+async def test_can_embed_with_builtins():
+    builtins = pgml.Builtins()
+    result = await builtins.embed("intfloat/e5-small-v2", "test")
+    assert result is not None
+
+@pytest.mark.asyncio
+async def test_can_embed_batch_with_builtins():
+    builtins = pgml.Builtins()
+    result = await builtins.embed_batch("intfloat/e5-small-v2", ["test"])
+    assert result is not None
+
 
 ###################################################
 ## Test searches ##################################

--- a/pgml-sdks/pgml/src/builtins.rs
+++ b/pgml-sdks/pgml/src/builtins.rs
@@ -116,7 +116,7 @@ impl Builtins {
         let texts = texts
             .0
             .as_array()
-            .with_context(|| "embed_batch takes an array of texts")?
+            .with_context(|| "embed_batch takes an array of strings")?
             .into_iter()
             .map(|v| {
                 v.as_str()
@@ -165,6 +165,30 @@ mod tests {
         let inputs = vec!["test1".to_string(), "test2".to_string()];
         let results = builtins.transform(task, inputs, None).await?;
         assert!(results.as_array().is_some());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn can_embed() -> anyhow::Result<()> {
+        internal_init_logger(None, None).ok();
+        let builtins = Builtins::new(None);
+        let results = builtins.embed("intfloat/e5-small-v2", "test").await?;
+        assert!(results.as_array().is_some());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn can_embed_batch() -> anyhow::Result<()> {
+        internal_init_logger(None, None).ok();
+        let builtins = Builtins::new(None);
+        let results = builtins
+            .embed_batch(
+                "intfloat/e5-small-v2",
+                Json(serde_json::json!(["test", "test2",])),
+            )
+            .await?;
+        assert!(results.as_array().is_some());
+        assert_eq!(results.as_array().unwrap().len(), 2);
         Ok(())
     }
 }


### PR DESCRIPTION
### SDK
1. Added `pgml.embed()` support into `Builtins`, with single and batch mode.