### PR TITLE
Allow to inject arbitrary components into the <head>

### DIFF
--- a/pgml-dashboard/src/components/layouts/head/mod.rs
+++ b/pgml-dashboard/src/components/layouts/head/mod.rs
@@ -1,4 +1,4 @@
-use pgml_components::component;
+use pgml_components::{component, Component};
 use sailfish::TemplateOnce;
 
 #[derive(TemplateOnce, Default, Clone)]
@@ -10,6 +10,7 @@ pub struct Head {
     pub preloads: Vec<String>,
     pub context: Option<String>,
     pub canonical: Option<String>,
+    pub additional_components: Vec<Component>,
 }
 
 impl Head {
@@ -56,6 +57,25 @@ impl Head {
 
     pub fn context(mut self, context: &Option<String>) -> Head {
         self.context = context.to_owned();
+        self
+    }
+
+    /// Add a component to `<head>`.
+    ///
+    /// This can be anything, e.g. a `<script>` tag or a `<meta>` or just some HTML or text.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use pgml_components::Component;
+    /// use pgml_components::layouts::Head;
+    ///
+    /// let head = Head::new()
+    ///     .add_component(Component::from("<script>console.log('hello');</script>"));
+    /// ```
+    ///
+    pub fn add_component(mut self, component: Component) -> Self {
+        self.additional_components.push(component);
         self
     }
 }

--- a/pgml-dashboard/src/components/layouts/head/template.html
+++ b/pgml-dashboard/src/components/layouts/head/template.html
@@ -97,4 +97,8 @@
     };
   </script>
   <% } %>
+
+  <% for component in additional_components { %>
+    <%+ component %>
+  <% } %>
 </head>

--- a/pgml-dashboard/src/components/layouts/marketing/base/mod.rs
+++ b/pgml-dashboard/src/components/layouts/marketing/base/mod.rs
@@ -3,7 +3,7 @@ use crate::components::notifications::marketing::AlertBanner;
 use crate::guards::Cluster;
 use crate::models::User;
 use crate::Notification;
-use pgml_components::component;
+use pgml_components::{component, Component};
 use sailfish::TemplateOnce;
 use std::fmt;
 
@@ -70,6 +70,15 @@ impl Base {
 
         rsp.head = head;
         rsp
+    }
+
+    /// Add a component to the `<head>`.
+    ///
+    /// See [`Head::add_component`](crate::components::layouts::Head::add_component) for more information.
+    ///
+    pub fn add_head_component(mut self, component: Component) -> Self {
+        self.head = self.head.add_component(component);
+        self
     }
 
     pub fn footer(mut self, footer: String) -> Self {

--- a/pgml-dashboard/src/templates/mod.rs
+++ b/pgml-dashboard/src/templates/mod.rs
@@ -163,6 +163,17 @@ impl<'a> WebAppBase<'a> {
         self
     }
 
+    /// Add a component to head (`<head>`).
+    ///
+    /// # Arguments
+    ///
+    /// * `component` - The component to add to the head.
+    ///
+    pub fn add_head_component(mut self, component: Component) -> Self {
+        self.head = self.head.add_component(component);
+        self
+    }
+
     pub fn render<T>(&mut self, template: T) -> String
     where
         T: sailfish::TemplateOnce,

--- a/pgml-dashboard/src/templates/mod.rs
+++ b/pgml-dashboard/src/templates/mod.rs
@@ -169,8 +169,8 @@ impl<'a> WebAppBase<'a> {
     ///
     /// * `component` - The component to add to the head.
     ///
-    pub fn add_head_component(mut self, component: Component) -> Self {
-        self.head = self.head.add_component(component);
+    pub fn add_head_component(&mut self, component: Component) -> &mut Self {
+        self.head = self.head.clone().add_component(component);
         self
     }
 


### PR DESCRIPTION
Allow to inject any HTML into any page rendered by the open source code on any page on postgresml.org. Notable limitation currently is we can't control the `<head>` on `/docs` since the handler is completely inside the dashboard.