### PR TITLE
Session cookie deserializaiton

### DIFF
--- a/pgml-dashboard/src/components/layouts/head/mod.rs
+++ b/pgml-dashboard/src/components/layouts/head/mod.rs
@@ -134,7 +134,7 @@ mod default_head_template_test {
 
     #[test]
     fn set_head() {
-        let mut head = Head::new()
+        let head = Head::new()
             .title("test title")
             .description("test description")
             .image("image/test_image.jpg");


### PR DESCRIPTION
1. Use serde for de(serialization).
2. Save the session cookie forever instead of just for 4 weeks.