### PR TITLE
Batch upsert documents

### DIFF
--- a/pgml-sdks/pgml/Cargo.lock
+++ b/pgml-sdks/pgml/Cargo.lock
@@ -1590,7 +1590,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pgml"
-version = "1.0.4"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/pgml-sdks/pgml/Cargo.toml
+++ b/pgml-sdks/pgml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgml"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 authors = ["PosgresML <team@postgresml.org>"]
 homepage = "https://postgresml.org/"

--- a/pgml-sdks/pgml/src/batch.rs
+++ b/pgml-sdks/pgml/src/batch.rs
@@ -1,0 +1,101 @@
+//! Upsert documents in batches.
+
+#[cfg(feature = "rust_bridge")]
+use rust_bridge::{alias, alias_methods};
+
+use tracing::instrument;
+
+use crate::{types::Json, Collection};
+
+#[cfg(feature = "python")]
+use crate::{collection::CollectionPython, types::JsonPython};
+
+#[cfg(feature = "c")]
+use crate::{collection::CollectionC, languages::c::JsonC};
+
+/// A batch of documents staged for upsert
+#[cfg_attr(feature = "rust_bridge", derive(alias))]
+#[derive(Debug, Clone)]
+pub struct Batch {
+    collection: Collection,
+    pub(crate) documents: Vec<Json>,
+    pub(crate) size: i64,
+    pub(crate) args: Option<Json>,
+}
+
+#[cfg_attr(feature = "rust_bridge", alias_methods(new, upsert_documents, finish,))]
+impl Batch {
+    /// Create a new upsert batch.
+    ///
+    /// # Arguments
+    ///
+    /// * `collection` - The collection to upsert documents to.
+    /// * `size` - The size of the batch.
+    /// * `args` - Optional arguments to pass to the upsert operation.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use pgml::{Collection, Batch};
+    ///
+    /// let collection = Collection::new("my_collection");
+    /// let batch = Batch::new(&collection, 100, None);
+    /// ```
+    pub fn new(collection: &Collection, size: i64, args: Option<Json>) -> Self {
+        Self {
+            collection: collection.clone(),
+            args,
+            documents: Vec::new(),
+            size,
+        }
+    }
+
+    /// Upsert documents into the collection. If the batch is full, save the documents.
+    ///
+    /// When using this method, remember to call [finish](Batch::finish) to save any remaining documents
+    /// in the last batch.
+    ///
+    /// # Arguments
+    ///
+    /// * `documents` - The documents to upsert.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use pgml::{Collection, Batch};
+    /// use serde_json::json;
+    ///
+    /// let collection = Collection::new("my_collection");
+    /// let mut batch = Batch::new(&collection, 100, None);
+    ///
+    /// batch.upsert_documents(vec![json!({"id": 1}), json!({"id": 2})]).await?;
+    /// batch.finish().await?;
+    /// ```
+    #[instrument(skip(self))]
+    pub async fn upsert_documents(&mut self, documents: Vec<Json>) -> anyhow::Result<()> {
+        for document in documents {
+            if self.size as usize >= self.documents.len() {
+                self.collection
+                    .upsert_documents(std::mem::take(&mut self.documents), self.args.clone())
+                    .await?;
+                self.documents.clear();
+            }
+
+            self.documents.push(document);
+        }
+
+        Ok(())
+    }
+
+    /// Save any remaining documents in the last batch.
+    #[instrument(skip(self))]
+    pub async fn finish(&mut self) -> anyhow::Result<()> {
+        if !self.documents.is_empty() {
+            self.collection
+                .upsert_documents(std::mem::take(&mut self.documents), self.args.clone())
+                .await?;
+        }
+
+        Ok(())
+    }
+}

--- a/pgml-sdks/pgml/src/lib.rs
+++ b/pgml-sdks/pgml/src/lib.rs
@@ -14,6 +14,7 @@ use tokio::runtime::{Builder, Runtime};
 use tracing::Level;
 use tracing_subscriber::FmtSubscriber;
 
+mod batch;
 mod builtins;
 #[cfg(any(feature = "python", feature = "javascript"))]
 mod cli;
@@ -40,6 +41,7 @@ mod utils;
 mod vector_search_query_builder;
 
 // Re-export
+pub use batch::Batch;
 pub use builtins::Builtins;
 pub use collection::Collection;
 pub use model::Model;
@@ -217,6 +219,7 @@ fn pgml(_py: pyo3::Python, m: &pyo3::types::PyModule) -> pyo3::PyResult<()> {
     m.add_class::<builtins::BuiltinsPython>()?;
     m.add_class::<transformer_pipeline::TransformerPipelinePython>()?;
     m.add_class::<open_source_ai::OpenSourceAIPython>()?;
+    m.add_class::<batch::BatchPython>()?;
     Ok(())
 }
 
@@ -275,6 +278,7 @@ fn main(mut cx: neon::context::ModuleContext) -> neon::result::NeonResult<()> {
         "newOpenSourceAI",
         open_source_ai::OpenSourceAIJavascript::new,
     )?;
+    cx.export_function("newBatch", batch::BatchJavascript::new)?;
     Ok(())
 }
 


### PR DESCRIPTION
### Features
1. [SDK] Add support for automatic batching for document upserts. Looking for review on the API before moving forward with PR, e.g. before adding tests.

```python
from pgml import Collection, Batch

collection = Collection("my_collection")
batch = Batch(collection, 25)

await batch.upsert_documents([{"id": 1}]) # Doesn't upsert yet

for i in range(23):
    await batch.upsert_documents([{"id": i}]) # Doesn't upsert yet

# Upserts whatever is in the current batch
# and appends the document to the next batch
await batch.upsert_documents([{"id": 1}])

# Upserts the final batch
await batch.finish()
```

### Bugs
1. [SDK] Formatting for long SQL queries.
3. [SDK] A couple of spelling typos.