### PR TITLE
Separate embedding kwargs into init kwargs and encode kwargs

### DIFF
--- a/pgml-extension/examples/embedding.sql
+++ b/pgml-extension/examples/embedding.sql
@@ -1,0 +1,7 @@
+\timing on
+
+SELECT pgml.embed('Alibaba-NLP/gte-base-en-v1.5', 'hi mom', '{"trust_remote_code": true}');
+SELECT pgml.embed('Alibaba-NLP/gte-base-en-v1.5', 'hi mom', '{"device": "cuda", "trust_remote_code": true}');
+SELECT pgml.embed('Alibaba-NLP/gte-base-en-v1.5', 'hi mom', '{"device": "cpu", "trust_remote_code": true}');
+SELECT pgml.embed('hkunlp/instructor-xl', 'hi mom', '{"instruction": "Encode it with love"}');
+SELECT pgml.embed('mixedbread-ai/mxbai-embed-large-v1', 'test', '{"prompt": "test prompt: "}');

--- a/pgml-extension/examples/image_classification.sql
+++ b/pgml-extension/examples/image_classification.sql
@@ -66,7 +66,7 @@ SELECT * FROM pgml.train('Handwritten Digits', algorithm => 'xgboost', hyperpara
 
 -- runtimes
 SELECT * FROM pgml.train('Handwritten Digits', algorithm => 'linear', runtime => 'python');
-SELECT * FROM pgml.train('Handwritten Digits', algorithm => 'linear', runtime => 'rust');
+--SELECT * FROM pgml.train('Handwritten Digits', algorithm => 'linear', runtime => 'rust');
 
 --SELECT * FROM pgml.train('Handwritten Digits', algorithm => 'xgboost', runtime => 'python', hyperparams => '{"n_estimators": 10}'); -- too slow
 SELECT * FROM pgml.train('Handwritten Digits', algorithm => 'xgboost', runtime => 'rust', hyperparams => '{"n_estimators": 10}');

--- a/pgml-extension/tests/test.sql
+++ b/pgml-extension/tests/test.sql
@@ -31,5 +31,6 @@ SELECT pgml.load_dataset('wine');
 \i examples/vectors.sql
 \i examples/chunking.sql
 \i examples/preprocessing.sql
+\i examples/embedding.sql
 -- transformers are generally too slow to run in the test suite
 --\i examples/transformers.sql


### PR DESCRIPTION
Resolves #1169

Hello!

## Pull Request overview
* Separate embedding kwargs into init kwargs and encode kwargs
* Introduces support for custom code models via `trust_remote_code` (e.g. #1169)
* Introduces support for private models via `token` (previously only possible via an environment variable, which FYI is still the recommended approach for security)
* Introduces support for Matryoshka models such as [this Vietnamese one](https://huggingface.co/hiieu/halong_embedding), which was trained such that embeddings can be truncated to smaller sizes with minimal performance loss & much faster retrieval, via `truncate_dim`.
* Introduces advanced loading support via `model_kwargs`/`tokenizer_kwargs`/`config_kwargs`. The first is most useful for inference, e.g. allowing loading models in lower precision for faster inference: `model_kwargs={"torch_dtype": "bfloat16"}`.

## Details
This PR splits `kwargs` in `pgml.embed` into two types of kwargs: for `model = SentenceTransformer(..., **kwargs)` and for `model.encode(..., **kwargs)`. This is currently done using a simple filter that checks for kwargs that are only (e.g. `trust_remote_code`) or primarily (e.g. `device`) relevant for the initialization.

I want to give a big preface that I have not tested this (!). My bandwidth is a bit too small this week for that I'm afraid. Another note is that `model_kwargs`/`tokenizer_kwargs`/`config_kwargs` and `truncate_dim` were only introduced in Sentence Transformers v3.0.0, whereas this project seems to be on v2.7 still. (FYI: ST v3.0 does not introduce breaking changes for inference, so upgrading should be safe).

- Tom Aarsen