### PR TITLE
Update template.html

### DIFF
--- a/pgml-dashboard/src/components/sections/have_questions/template.html
+++ b/pgml-dashboard/src/components/sections/have_questions/template.html
@@ -5,3 +5,4 @@
     <h4>Have more questions?</h4>
     <p><a class="text-decoration-underline" href="https://discord.gg/DmyJP3qJ7U">Join our Discord</a> to chat with our team and the community.</p>
   </div>
+</div>

--- a/pgml-dashboard/src/components/sections/have_questions/template.html
+++ b/pgml-dashboard/src/components/sections/have_questions/template.html
@@ -2,21 +2,6 @@
 
 <div class="d-flex flex-column gap-4" data-controller="sections-have-questions">
   <div class="w-100 justify-content-center d-flex flex-column text-center">
-    <h4>Have Questions?</h4>
-    <p><a class="text-decoration-underline" href="https://discord.gg/DmyJP3qJ7U">Join our Discord</a> and ask us anything! We're friendly and would love to talk about PostgresML and PgCat.</p>
+    <h4>Have more questions?</h4>
+    <p><a class="text-decoration-underline" href="https://discord.gg/DmyJP3qJ7U">Join our Discord</a> to chat with our team and the community.</p>
   </div>
-
-  <div class="w-100 text-center">
-    <p class="h3 m-0">🦉</p>
-  </div>
-  
-  <% if !standalone_dashboard() { %>
-  <div class="w-100 justify-content-center d-flex flex-column text-center">
-    <h4>Try PostresML using our free serverless cloud. </h4>
-  </div>
-
-  <div class="d-flex justify-content-center">
-    <a class="btn btn-primary" href="<%- crate::utils::config::signup_url() %>">Start Your Project</a>
-  </div>
-  <% } %>
-</div>


### PR DESCRIPTION
updated copy, removed CTA - 

Was going to just update the copy to reflect updated pricing and include Korvus, but I think we should remove the CTA here all together. Doesn't make sense imo to have any CTAs to Get Started in docs. Plus we've got the same one in the sticky nav at the top. Don't want to sell to folks we are trying to educate